### PR TITLE
Duplicate transfer round: 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ What's working:
 * [elliottcarlson](https://github.com/elliottcarlson) for the Google Auth PR  
 * [AeonLucid](https://github.com/AeonLucid/POGOProtos) for improved protos  
 * [AHAAAAAAA](https://github.com/AHAAAAAAA/PokemonGo-Map) for parts of the s2sphere stuff
+* [beeedy](https://github.com/beeedy) for ability to transfer duplicate pokemon
 * And to anyone on the pokemongodev slack channel <3
 
 >>>>>>> super sketch but yolo

--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Usage:
      * Setting this to 500 means avoid a fort for 500 seconds before returning, (Should be higher than 300 to have any effect). This will let the bot explore a bigger area.
     * `SPIN_ALL_FORTS` [Experimental] will try to route using google maps(must have key) to all visible forts, if `SKIP_VISITED_FORT_DURATION` is set high enough, you may roam around forever.
     * `KEEP_POKEMON_IDS` IDs of pokemon you want the bot to hold regardless of IV/CP
-
- * Run python web.py to get a webservice to show you player information, this can be seen at:
-  * http://127.0.0.1:5000/YOUR_USERNAME_HERE/pokemon
-  * Only 1 needs to run regardless of how many bots you are running
+    
+    * `RELEASE_DUPLICATES` The bot seems to have a bad habit of hoarding pokemon. Enabling this feature (disabled by default) will have the bot automatically transfer pokemon that are duplicates. To determine which pokemon to transfer when duplicates exist, the lvl's of the pokemon are compared. A pokemon's lvl is an arbitrary and configurable parameter that can either be representative of a pokemon's CP, IV, CPxIV, or CP+IV. The bot will transfer the lowest lvl pokemon, maintaining` MIN_SIMILAR_POKEMON` of each type. To be completely confident that the bot will not transfer your high lvl pokemon, when this feature is enabled only pokemon with a lvl below `RELEASE_DUPLICATES_MAX_LVL`. If you have multiple pokemon that are close to the same lvl the bot can be configured to not transfer them by using `RELEASE_DUPLICATES_SCALER`. The value of this config is multiplied by the highest lvl pokemon of a type and only those pokemon that are less than the scaled lvl are transfered. 
+     * EXAMPlES: If you set lvl to "IV" while having two Snorlaxs, one with stats CP:14 IV:95 and the other with CP:1800 IV:30 the bot will transfer the Snorlax with CP of 1800 and keep the CP 14 Snorlax because you have indicated you only care about a pokemon's IV. It must be fully understood why this happens to avoid unwanted transfer of pokemon. If not used correctly this feature can very easily transfer a large ammount of your pokemon so please make sure you fully understand it's mechanics before attempting use! 
 
 
 ## Requirements

--- a/config.json.example
+++ b/config.json.example
@@ -35,6 +35,10 @@
       "KEEP_POKEMON_NAMES": ["MEWTWO"],
       "THROW_POKEMON_NAMES": ["PIDGEY"],
       "MAX_CATCH_ATTEMPTS": 10
+        "RELEASE_DUPLICATES": false,
+        "RELEASE_DUPLICATES_MAX_LV": 1000,
+        "RELEASE_DUPLICATES_SCALER": 0.9,
+        "DEFINE_POKEMON_LV": "CP"
     },
     {
       "auth_service": "ptc",

--- a/config.json.example
+++ b/config.json.example
@@ -34,11 +34,11 @@
       "MIN_SIMILAR_POKEMON": 1,
       "KEEP_POKEMON_NAMES": ["MEWTWO"],
       "THROW_POKEMON_NAMES": ["PIDGEY"],
-      "MAX_CATCH_ATTEMPTS": 10
-        "RELEASE_DUPLICATES": false,
-        "RELEASE_DUPLICATES_MAX_LV": 1000,
-        "RELEASE_DUPLICATES_SCALER": 0.9,
-        "DEFINE_POKEMON_LV": "CP"
+      "MAX_CATCH_ATTEMPTS": 10,
+      "RELEASE_DUPLICATES": false,
+      "RELEASE_DUPLICATES_MAX_LV": 1000,
+      "RELEASE_DUPLICATES_SCALER": 0.9,
+      "DEFINE_POKEMON_LV": "CP"
     },
     {
       "auth_service": "ptc",

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -437,7 +437,7 @@ class PGoApi:
                 # highest lvl pokemon first
                 pokemons = sorted(pokemons, key=self.pokemon_lvl, reverse=True)
                 for pokemon in pokemons[self.MIN_SIMILAR_POKEMON:]:
-                    if self.RELEASE_DUPLICATES and pokemon is not pokemons[0]:
+                    if self.RELEASE_DUPLICATES and pokemon is not pokemons[0] and not pokemon.is_favorite and not pokemon.pokemon_id in self.keep_pokemon_ids:
                         if self.pokemon_lvl(pokemons[0]) * self.RELEASE_DUPLICATES_SCALER > self.pokemon_lvl(pokemon) and pokemon.cp < self.RELEASE_DUPLICATES_MAX_LV:
                             self.do_release_pokemon(pokemon)
                     elif self.is_pokemon_eligible_for_transfer(pokemon):

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -468,6 +468,20 @@ class PGoApi:
         elif self.DEFINE_POKEMON_LV == "CP+IV":
             return pokemon.cp + pokemon.iv
 
+    def attempt_evolve(self, inventory_items=None):
+        if not inventory_items:
+            inventory_items = self.get_inventory().call()['responses']['GET_INVENTORY']['inventory_delta'][
+                'inventory_items']
+        caught_pokemon = self.get_caught_pokemons(inventory_items)
+        self.inventory = Player_Inventory(inventory_items)
+        for pokemons in caught_pokemon.values():
+            if len(pokemons) > self.MIN_SIMILAR_POKEMON:
+                pokemons = sorted(pokemons, key=lambda x: (x.cp, x.iv), reverse=True)
+                for pokemon in pokemons[self.MIN_SIMILAR_POKEMON:]:
+                    # If we can't evolve this type of pokemon anymore, don't check others.
+                    if not self.attempt_evolve_pokemon(pokemon):
+                        break
+
     def attempt_evolve_pokemon(self, pokemon):
         if self.is_pokemon_eligible_for_evolution(pokemon=pokemon):
             self.log.info("Evolving pokemon: %s", pokemon)

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -458,60 +458,6 @@ class PGoApi:
         else:
             return True
 
-    # def cleanup_pokemon(self, inventory_items=None):
-    #     if not inventory_items:
-    #             inventory_items = self.get_inventory().call()['responses']['GET_INVENTORY']['inventory_delta'][
-    #                 'inventory_items']
-    #     caught_pokemon = self.get_caught_pokemons(inventory_items)
-
-    #     for pokemons in caught_pokemon.values():
-    #         # Only if we have more than MIN_SIMILAR_POKEMON
-    #         if len(pokemons) > MIN_SIMILAR_POKEMON:
-    #             pokemons = sorted(pokemons, key=lambda x: (x.iv, x.cp), reverse=True)
-    #             # keep the first pokemon....
-    #             last_pokemon = pokemons[0]
-    #             for pokemon in pokemons[MIN_SIMILAR_POKEMON:]:
-    #                 if self.pokemon_lvl(pokemon) > self.pokemon_lvl(last_pokemon) and self.RELEASE_DUPLICATES:
-    #                     if self.pokemon_lvl(pokemon) * self.RELEASE_DUPLICATES_SCALER > self.pokemon_lvl(last_pokemon) and self.pokemon_lvl(last_pokemon) < self.RELEASE_DUPLICATES_MAX_LV:
-    #                         self.log.info("Releasing pokemon: %s", last_pokemon)
-    #                         self.release_pokemon(pokemon_id = last_pokemon.id)
-    #                         release_res = self.call()['responses']['RELEASE_POKEMON']
-    #                         status = release_res.get('result', -1)
-    #                         if status == 1:
-    #                             self.log.info("Successfully Released Pokemon %s", pokemon)
-    #                         else:
-    #                             self.log.debug("Failed to release pokemon %s, %s", pokemon, release_res)
-    #                             self.log.info("Failed to release Pokemon %s", pokemon)
-    #                         sleep(3)
-    #                     last_pokemon = pokemon
-    #                 elif self.pokemon_lvl(last_pokemon) * self.RELEASE_DUPLICATES_SCALER > self.pokemon_lvl(pokemon) and self.pokemon_lvl(pokemon) < self.RELEASE_DUPLICATES_MAX_LV and self.RELEASE_DUPLICATES:
-    #                     self.log.info("Releasing pokemon: %s", pokemon)
-    #                     self.release_pokemon(pokemon_id = pokemon.id)
-    #                     release_res = self.call()['responses']['RELEASE_POKEMON']
-    #                     status = release_res.get('result', -1)
-    #                     if status == 1:
-    #                         self.log.info("Successfully Released Pokemon %s", pokemon)
-    #                     else:
-    #                         self.log.debug("Failed to release pokemon %s, %s", pokemon, release_res)
-    #                         self.log.info("Failed to release Pokemon %s", pokemon)
-    #                     sleep(3)
-    #                 elif pokemon.iv < self.MIN_KEEP_IV and pokemon.cp < self.KEEP_CP_OVER and pokemon.is_valid_pokemon():
-    #                     self.log.info("Releasing pokemon: %s", pokemon)
-    #                     self.release_pokemon(pokemon_id=pokemon.id)
-    #                     release_res = self.call()['responses']['RELEASE_POKEMON']
-    #                     status = release_res.get('result', -1)
-    #                     if status == 1:
-    #                         self.log.info("Successfully Released Pokemon %s", pokemon)
-    #                     else:
-    #                         self.log.debug("Failed to release pokemon %s, %s", pokemon, release_res)
-    #                         self.log.info("Failed to release Pokemon %s", pokemon)
-    #                     sleep(3)
-    #         if len(pokemons) > self.MIN_SIMILAR_POKEMON:
-    #             # highest CP pokemon first
-    #             pokemons = sorted(pokemons, key=lambda pok: (pok.cp, pok.iv), reverse=True)
-    #             pokemons_keep_counter = 0
-    #             pokemons_keep_iv_counter = 0
-
     def pokemon_lvl(self, pokemon):
         if self.DEFINE_POKEMON_LV == "CP":
             return pokemon.cp
@@ -521,45 +467,6 @@ class PGoApi:
             return pokemon.cp * pokemon.iv
         elif self.DEFINE_POKEMON_LV == "CP+IV":
             return pokemon.cp + pokemon.iv
-
-    def is_pokemon_eligible_for_transfer(self, pokemon, pokemons_keep_counter,
-                                         pokemons_keep_iv_counter,
-                                         best_pokemon=Pokemon()):
-        # never release favorites and other defined pokemons
-        if pokemon.is_favorite or pokemon.pokemon_id in self.keep_pokemon_ids:
-            pokemons_keep_counter += 1
-            return False, True
-        # release defined throwaway pokemons  but make sure we have kept at least 1 (dont throw away all of them)
-        elif pokemon.pokemon_id in self.throw_pokemon_ids and pokemons_keep_counter >= 1:
-            return True, True
-        # keep high-iv pokemons based on config values
-        elif pokemon.iv > self.KEEP_IV_OVER \
-                and pokemons_keep_iv_counter < self.MAX_POKEMON_HIGH_IV \
-                and (pokemon.cp * self.KEEP_IV_MIN_PERCENT_CP / 100) > (best_pokemon.cp * self.KEEP_IV_MIN_PERCENT_CP / 100):
-            return False, False
-        # keep high-cp pokemons and first MIN_SIMILAR_POKEMON amount of pokemons
-        elif pokemon.cp > self.KEEP_CP_OVER:
-            return False, True
-        # release all other pokemons
-        elif pokemons_keep_counter >= self.MIN_SIMILAR_POKEMON:
-            return True, True
-        return False, True
-
-    def attempt_evolve(self, inventory_items=None):
-        if not inventory_items:
-            inventory_items = self.get_inventory().call()['responses']['GET_INVENTORY']['inventory_delta'][
-                'inventory_items']
-        caught_pokemon = self.get_caught_pokemons(inventory_items)
-        self.inventory = Player_Inventory(inventory_items)
-        for pokemons in caught_pokemon.values():
-            if len(pokemons) > self.MIN_SIMILAR_POKEMON:
-                pokemons = sorted(pokemons, key=lambda x: (x.cp, x.iv), reverse=True)
-                for pokemon in pokemons[self.MIN_SIMILAR_POKEMON:]:
-                    # If we can't evolve this type of pokemon anymore, don't check others.
-                    if not self.attempt_evolve_pokemon(pokemon):
-                        break
-
-        return False
 
     def attempt_evolve_pokemon(self, pokemon):
         if self.is_pokemon_eligible_for_evolution(pokemon=pokemon):

--- a/pokecli.py
+++ b/pokecli.py
@@ -72,8 +72,18 @@ def init_configs():
     config = parser.parse_args()
     loaded = [load['accounts'][i] for i in config.accounts]
     # Passed in arguments shoud trump
-    return loaded
+    for key,value in load.iteritems():
+        if key not in config.__dict__ or not config.__dict__[key]:
+            config.__dict__[key] = value
+    if config.auth_service not in ['ptc', 'google']:
+        log.error("Invalid Auth service specified! ('ptc' or 'google')")
+        return None
 
+    if "DEFINE_POKEMON_LV" in config.__dict__ and config.DEFINE_POKEMON_LV not in ['CP', 'IV', 'CP*IV', 'CP+IV']:
+        log.error("Invalid pokemon lvl definer! ('CP' or 'IV' or 'CP*IV' or 'CP+IV')")
+        return None
+
+    return config
 
 def main():
     # log settings

--- a/pokecli.py
+++ b/pokecli.py
@@ -72,18 +72,7 @@ def init_configs():
     config = parser.parse_args()
     loaded = [load['accounts'][i] for i in config.accounts]
     # Passed in arguments shoud trump
-    for key,value in load.iteritems():
-        if key not in config.__dict__ or not config.__dict__[key]:
-            config.__dict__[key] = value
-    if config.auth_service not in ['ptc', 'google']:
-        log.error("Invalid Auth service specified! ('ptc' or 'google')")
-        return None
-
-    if "DEFINE_POKEMON_LV" in config.__dict__ and config.DEFINE_POKEMON_LV not in ['CP', 'IV', 'CP*IV', 'CP+IV']:
-        log.error("Invalid pokemon lvl definer! ('CP' or 'IV' or 'CP*IV' or 'CP+IV')")
-        return None
-
-    return config
+    return loaded
 
 def main():
     # log settings


### PR DESCRIPTION
I am not sure what is blocking the auto-merge but this should be the completed branch that allows for the release of duplicate pokemon! 

As mentioned before this is a feature that is disabled by default and should be carefully configured to avoid unwanted loss of pokemon. This introduces a couple new concepts including that of a pokemon's LVL which is a configurable value comprised of CP and IV. At its core this feature allows for you to specify how the system should compare two pokemon in regards to CP and IV using their new LVL and also remove *all duplicates. The new config "RELEASE_DUPLICATES_SCALER" is a value multiplied by the highest lvl pokemon of a type's lvl. The bot will only transfer pokemon with a lvl that is less than this product. This in essence allows a user to keep pokemon that are close together in lvl so that they can manually decide which to transfer. To disable this, set RELEASE_DUPLICATES_SCALER to 1.0

"all" comes with some stipulations. It will still abide by the configuration "MIN_SIMILAR_POKEMON" and also will not release pokemon above the LVL limit specified by RELEASE_DUPLICATES_MAX_LV. Pokemon also flagged as favorites or in the list of pokemon to keep will not be transferred. 

NOTE: THIS IS IMPORTANT!!! DO NOT IGNORE THIS!!!!! WHEN YOU ENABLE THE TRANSFER OF DUPLICATES, YOU ARE ALSO DISABLING THE CONFIGS "KEEP_IV_OVER" AND "KEEP_CP_OVER". 