### PR TITLE
Fix transfer logic when not using RELEASE_DUPLICATES feature.

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -548,9 +548,14 @@ class PGoApi:
                         if self.is_pokemon_eligible_for_transfer(pokemon, sorted_pokemons[0]):
                             self.do_release_pokemon(pokemon)
                 else:
+                    remaining = len(pokemons)
                     for pokemon in pokemons:
                         if self.is_pokemon_eligible_for_transfer(pokemon, None):
                             self.do_release_pokemon(pokemon)
+                            remaining -= 1
+                        if remaining <= self.MIN_SIMILAR_POKEMON:
+                            break
+
 
 
     def is_pokemon_eligible_for_transfer(self, pokemon, best_pokemon):

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -541,11 +541,17 @@ class PGoApi:
         caught_pokemon = self.get_caught_pokemons(inventory_items)
         for pokemons in caught_pokemon.values():
             if len(pokemons) > self.MIN_SIMILAR_POKEMON:
-                # highest lvl pokemon first
-                sorted_pokemons = sorted(pokemons, key=self.pokemon_lvl, reverse=True)
-                for pokemon in sorted_pokemons[self.MIN_SIMILAR_POKEMON:]:
-                    if self.is_pokemon_eligible_for_transfer(pokemon, sorted_pokemons[0]):
-                        self.do_release_pokemon(pokemon)
+                if self.RELEASE_DUPLICATES:
+                    sorted_pokemons = sorted(pokemons, key=self.pokemon_lvl, reverse=True)
+
+                    for pokemon in sorted_pokemons[self.MIN_SIMILAR_POKEMON:]:
+                        if self.is_pokemon_eligible_for_transfer(pokemon, sorted_pokemons[0]):
+                            self.do_release_pokemon(pokemon)
+                else:
+                    for pokemon in pokemons:
+                        if self.is_pokemon_eligible_for_transfer(pokemon, None):
+                            self.do_release_pokemon(pokemon)
+
 
     def is_pokemon_eligible_for_transfer(self, pokemon, best_pokemon):
         # never release favorites and other defined pokemons


### PR DESCRIPTION
If RELEASE_DUPLICATES is set to false (by default), there is no need to sort the Pokemon by "LVL" since the subsequent logic does not refer to LVL, but rather both IV and CP for KEEP_MIN_IV and KEEP_MIN_CP respectively. If we don't do this, we're also incorrectly not processing one of the Pokemon since we would be skipping it in the loop:
`sorted_pokemons[self.MIN_SIMILAR_POKEMON:]`