### PR TITLE
Allow bot to stop catching pokemon and farm balls when inventory is depleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ optional arguments:
      * `BIG_EGGS_FIRST` incubate big eggs (most km) first (default: true)
     * `RELEASE_DUPLICATES` The bot seems to have a bad habit of hoarding pokemon. Enabling this feature (disabled by default) will have the bot automatically transfer pokemon that are duplicates. To determine which pokemon to transfer when duplicates exist, the lvl's of the pokemon are compared. A pokemon's lvl is an arbitrary and configurable parameter that can either be representative of a pokemon's CP, IV, CPxIV, or CP+IV. The bot will transfer the lowest lvl pokemon, maintaining` MIN_SIMILAR_POKEMON` of each type. To be completely confident that the bot will not transfer your high lvl pokemon, when this feature is enabled only pokemon with a lvl below `RELEASE_DUPLICATES_MAX_LVL`. If you have multiple pokemon that are close to the same lvl the bot can be configured to not transfer them by using `RELEASE_DUPLICATES_SCALER`. The value of this config is multiplied by the highest lvl pokemon of a type and only those pokemon that are less than the scaled lvl are transfered.
      * EXAMPlES: If you set lvl to "IV" while having two Snorlaxs, one with stats CP:14 IV:95 and the other with CP:1800 IV:30 the bot will transfer the Snorlax with CP of 1800 and keep the CP 14 Snorlax because you have indicated you only care about a pokemon's IV. It must be fully understood why this happens to avoid unwanted transfer of pokemon. If not used correctly this feature can very easily transfer a large ammount of your pokemon so please make sure you fully understand it's mechanics before attempting use!
-
+    * `NEEDY_ITEM_FARMING` [Experimental] will cease trying to catch pokemon and roam around to collect more pokeballs when inventory is low
+     * `ENABLE` : `Boolean`, whether or not this feature is enabled
+     * `POKEBALL_FARM_THRESHOLD` : `Integer`, when the observed pokeball count drops on or below this number, skip catching pokemon and begin collecting.
+     * `POKEBALL_CONTINUE_THRESHOLD`: `Integer`, when the observed pokeball count reaches this amount, stop farming and go back to catching pokemon.
+     * `FARM_IGNORE_POKEBALL_COUNT`: `Boolean`, Whether to include this ball in counting. Same goes for `GREATBALL`, `ULTRABALL`, and `MASTERBALL`. Masterball is ignored by default.
+     * `FARM_OVERRIDE_STEP_SIZE`: `Integer`, When it goes into farming mode, the bot assumes this step size to potentially speed up resource gathering. _This might lead to softbans._ Setting to `-1` disables this feature. Disabled by default for safety.
+     * If `EXPERIMENTAL` OR `CATCH_POKEMON` are false, this configuration will disable itself.
 
 ## Requirements
  * Run `pip install -r requirements.txt`

--- a/config.json.example
+++ b/config.json.example
@@ -31,6 +31,16 @@
         "ITEM_MAX_REVIVE": 10,
         "ITEM_RAZZ_BERRY": 10
       },
+      "NEEDY_ITEM_FARMING": {
+        "ENABLE": true,
+        "POKEBALL_CONTINUE_THRESHOLD": 50,
+        "POKEBALL_FARM_THRESHOLD": 10,
+        "FARM_IGNORE_POKEBALL_COUNT": false,
+        "FARM_IGNORE_GREATBALL_COUNT": false,
+        "FARM_IGNORE_ULTRABALL_COUNT": false,
+        "FARM_IGNORE_MASTERBALL_COUNT": true,
+        "FARM_OVERRIDE_STEP_SIZE": -1
+      },
       "POKEMON_EVOLUTION": {
         "PIDGEY": 12,
         "WEEDLE":12


### PR DESCRIPTION
I found it kinda annoying to switch the bot in-between collecting and catching. This was my solution.

Flags:
`ENABLE` : `Boolean`, whether or not this feature is enabled
`POKEBALL_FARM_THRESHOLD` : `Integer`, when the observed pokeball count drops on or below this number, skip catching pokemon and begin collecting.
`POKEBALL_CONTINUE_THRESHOLD`: `Integer`, when the observed pokeball count reaches this amount, stop farming and go back to catching pokemon.
`FARM_IGNORE_POKEBALL_COUNT`: `Boolean`, Whether to include this ball in counting. Same goes for `GREATBALL`, `ULTRABALL`, and `MASTERBALL`. Masterball is ignored by default.
`FARM_OVERRIDE_STEP_SIZE`: `Integer`, When it goes into farming mode, the bot assumes this step size to potentially speed up resource gathering. _This might lead to softbans, I'm not savvy with what causes issues._, but it works for me. Setting to `-1` disables this feature. Disabled by default for safety.