### PR TITLE
pokemon level, normalized iv, improved max_cp

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -278,7 +278,7 @@ class PGoApi:
             self.log.debug(self.cleanup_inventory(self.inventory.inventory_items))
             self.log.info("Player Inventory after cleanup: %s", self.inventory)
             if self.LIST_POKEMON_BEFORE_CLEANUP:
-                self.log.info(get_inventory_data(res, self.pokemon_names))
+                self.log.info(get_inventory_data(res, self.pokemon_names, self.game_master, self.player_stats.level))
             self.incubate_eggs()
             self.attempt_evolve(self.inventory.inventory_items)
             self.cleanup_pokemon(self.inventory.inventory_items)
@@ -590,7 +590,9 @@ class PGoApi:
             if "pokemon_data" in inventory_item['inventory_item_data']:
                 # is a pokemon:
                 pokemon_data = inventory_item['inventory_item_data']['pokemon_data']
-                pokemon = Pokemon(pokemon_data, self.pokemon_names, self.game_master.get(pokemon_data.get('pokemon_id', 0), PokemonData()))
+                pokemon = Pokemon(pokemon_data, self.pokemon_names,
+                                  self.game_master.get(pokemon_data.get('pokemon_id', 0), PokemonData()),
+                                  self.player_stats.level)
 
                 if not pokemon.is_egg:
                     caught_pokemon[pokemon.pokemon_id].append(pokemon)
@@ -680,7 +682,8 @@ class PGoApi:
             sleep(3)
             if status == 1:
                 evolved_pokemon = Pokemon(evo_res.get('evolved_pokemon_data', {}), self.pokemon_names,
-                                          self.game_master.get(str(pokemon.pokemon_id), PokemonData()))
+                                          self.game_master.get(str(pokemon.pokemon_id), PokemonData()),
+                                          self.player_stats.level)
                 # I don' think we need additional stats for evolved pokemon. Since we do not do anything with it.
                 # evolved_pokemon.pokemon_additional_data = self.game_master.get(pokemon.pokemon_id, PokemonData())
                 self.log.info("Evolved to %s", evolved_pokemon)

--- a/pgoapi/poke_utils.py
+++ b/pgoapi/poke_utils.py
@@ -36,10 +36,12 @@ def pokemonIVPercentage(pokemon):
         'individual_defense', 0) + 0.0) / 45.0) * 100.0
 
 
-def get_inventory_data(res, poke_names):
+def get_inventory_data(res, poke_names, game_master, player_level):
     inventory_delta = res['responses']['GET_INVENTORY'].get('inventory_delta', {})
     inventory_items = inventory_delta.get('inventory_items', [])
-    pokemons = sorted(map(lambda x: Pokemon(x['pokemon_data'], poke_names),
+    pokemons = sorted(map(lambda x: Pokemon(x['pokemon_data'], poke_names,
+                                            game_master.get(x['pokemon_data'].get('pokemon_id', 0), PokemonData()),
+                                            player_level),
                           filter(lambda x: 'pokemon_data' in x,
                           map(lambda x: x.get('inventory_item_data', {}), inventory_items))), key=lambda x: x.cp, reverse=True)
     inventory_items_pokemon_list = filter(lambda x: not x.is_egg, pokemons)

--- a/pgoapi/pokemon.py
+++ b/pgoapi/pokemon.py
@@ -82,7 +82,7 @@ class Pokemon:
 
         if self.max_cp > 0:
             return "{0}Type: {1} CP: {2}, IV: {3:.2f}, Lvl: {4:.1f}, " \
-                   "LvlWild: {5:.1f}, MaxCP: {6:.0f}, MaxCPAbs: {7:.0f}, IV-Score: {8:.0f}".format(nickname,
+                   "LvlWild: {5:.1f}, MaxCP: {6:.0f}, MaxCPAbs: {7:.0f}, IV-Norm.: {8:.0f}".format(nickname,
                                                                                                    self.pokemon_type,
                                                                                                    self.cp, self.iv,
                                                                                                    self.level,

--- a/pgoapi/pokemon.py
+++ b/pgoapi/pokemon.py
@@ -1,7 +1,34 @@
 from math import sqrt
 
+
 class Pokemon:
-    def __init__(self, pokemon_data=dict(), pokemon_names=dict(), additional_data=None):
+    # Used for calculating the pokemon level
+    # source http://pokemongo.gamepress.gg/cp-multiplier
+    CPM_calculation_increments = [
+        {
+            'max_level': 1,
+            'cpm_sqrt_increase_per_level': 0.008836,
+            'max_level_cpm': 0.094  # we can't calculate this value, thus we set it here
+        },
+        {
+            'max_level': 10,
+            'cpm_sqrt_increase_per_level': 0.009426125*2
+        },
+        {
+            'max_level': 20,
+            'cpm_sqrt_increase_per_level': 0.008919026*2
+        },
+        {
+            'max_level': 30,
+            'cpm_sqrt_increase_per_level': 0.008924906*2
+        },
+        {
+            'max_level': 40,
+            'cpm_sqrt_increase_per_level': 0.004459461*2
+        }
+    ]
+
+    def __init__(self, pokemon_data=dict(), pokemon_names=dict(), additional_data=None, player_level=0):
         self.pokemon_data = pokemon_data
         self.stamina = pokemon_data.get('stamina', 0)
         self.favorite = pokemon_data.get('favorite', -1)
@@ -23,21 +50,29 @@ class Pokemon:
         self.iv = self.get_iv_percentage()
         self.pokemon_type = pokemon_names.get(str(self.pokemon_id), "NA").encode('utf-8', 'ignore')
         self.pokemon_additional_data = additional_data
-
+        self.iv_normalized = -1.0
         self.max_cp = -1.0
-        self.score = -1.0
-
+        self.max_cp_absolute = -1.0
+        self.cpm_total = self.cp_multiplier + self.additional_cp_multiplier
+        self.level_wild = self.get_level_by_cpm(self.cp_multiplier)
+        self.level = self.get_level_by_cpm(self.cpm_total)
         if additional_data is not None:
             # Thanks to http://pokemongo.gamepress.gg/pokemon-stats-advanced for the magical formulas
-            cp_multiplier = self.cp_multiplier + self.additional_cp_multiplier
-            attack = float(additional_data.BaseAttack) + 15
-            defense = float(additional_data.BaseDefense) + 15
-            stamina = float(additional_data.BaseStamina) + 15
-
-            self.max_cp = (attack * sqrt(defense) * sqrt(stamina) * cp_multiplier * cp_multiplier) / 10
-
-            if self.max_cp > 0:
-                self.score = self.iv / 100.0 * 0.5 + self.cp / self.max_cp * 0.5
+            attack = float(additional_data.BaseAttack)
+            defense = float(additional_data.BaseDefense)
+            stamina = float(additional_data.BaseStamina)
+            worst_iv_cp = (attack * sqrt(defense) * sqrt(stamina) * pow(self.cpm_total, 2)) / 10
+            perfect_iv_cp = ((attack + 15) * sqrt(defense + 15) * sqrt(stamina + 15) * pow(self.cpm_total, 2)) / 10
+            if perfect_iv_cp - worst_iv_cp > 0:
+                self.iv_normalized = 100 * (self.cp - worst_iv_cp) / (perfect_iv_cp - worst_iv_cp)
+            self.max_cp = ((attack + self.individual_attack) *
+                           sqrt(defense + self.individual_defense) *
+                           sqrt(stamina + self.individual_stamina) *
+                           pow(self.get_cpm_by_level(player_level+1.5), 2)) / 10
+            self.max_cp_absolute = ((attack + self.individual_attack) *
+                           sqrt(defense + self.individual_defense) *
+                           sqrt(stamina + self.individual_stamina) *
+                           pow(self.get_cpm_by_level(40), 2)) / 10
 
     def __str__(self):
         nickname = ""
@@ -46,12 +81,65 @@ class Pokemon:
             nickname = "Nickname: " + self.nickname + ", "
 
         if self.max_cp > 0:
-            return "{0}Type: {1}, CP: {2}, IV: {3:.2f}, Max CP: {4:.0f}, Score: {5:.2f}".format(nickname, self.pokemon_type, self.cp, self.iv, self.max_cp, self.score)
+            return "{0}Type: {1} CP: {2}, IV: {3:.2f}, Lvl: {4:.1f}, " \
+                   "LvlWild: {5:.1f}, MaxCP: {6:.0f}, MaxCPAbs: {7:.0f}, IV-Score: {8:.0f}".format(nickname,
+                                                                                                   self.pokemon_type,
+                                                                                                   self.cp, self.iv,
+                                                                                                   self.level,
+                                                                                                   self.level_wild,
+                                                                                                   self.max_cp,
+                                                                                                   self.max_cp_absolute,
+                                                                                                   self.iv_normalized)
         else:
-            return "{0}Type: {1}, CP: {2}, IV: {3:.2f}".format(nickname, self.pokemon_type, self.cp, self.iv)
+            return "{0}Type: {1}, CP: {2}, IV: {3:.2f}, Lvl: {4:.1f}, LvlWild: {5:.1f}".format(nickname,
+                                                                                                self.pokemon_type,
+                                                                                                self.cp, self.iv,
+                                                                                                self.level,
+                                                                                                self.level_wild)
 
     def __repr__(self):
         return self.__str__()
+
+    def get_level_by_cpm(self, cpm_total):
+        prev_max_level = 0
+        prev_max_level_cpm = 0
+        for cpm_increment in self.CPM_calculation_increments:
+            max_level = cpm_increment['max_level']
+            cpm_sqrt_increase_per_level = cpm_increment['cpm_sqrt_increase_per_level']
+            if "max_level_cpm" in cpm_increment:
+                max_level_cpm = cpm_increment['max_level_cpm']
+            else:
+                # this calculates the CPM for a pokemon with max_level of the current iteration
+                max_level_cpm = self.get_cpm_by_level(max_level)
+            if cpm_total <= max_level_cpm:
+                # cpm_sqrt_increase_per_level is only valid for CPM increase since prev_max_level
+                level_diff_prev_max_level = (pow(cpm_total, 2) - pow(prev_max_level_cpm, 2)) / cpm_sqrt_increase_per_level
+                return round(prev_max_level + level_diff_prev_max_level, 1)
+            else:
+                prev_max_level = max_level
+                prev_max_level_cpm = max_level_cpm
+        return 0.0
+
+    def get_cpm_by_level(self, level):
+        prev_max_level = 0
+        prev_max_level_cpm = 0
+        for cpm_increment in self.CPM_calculation_increments:
+            max_level = cpm_increment['max_level']
+            cpm_sqrt_increase_per_level = cpm_increment['cpm_sqrt_increase_per_level']
+            if level <= max_level:  # we are below the max level of current cpm iteration
+                # this calculates the CPM for a pokemon with given level
+                return sqrt(
+                    pow(prev_max_level_cpm, 2) +
+                    cpm_sqrt_increase_per_level * (level - prev_max_level)
+                )
+            else:
+                # this calculates the CPM for a pokemon with max_level, used in next iteration
+                prev_max_level_cpm = sqrt(
+                    pow(prev_max_level_cpm, 2) +
+                    cpm_sqrt_increase_per_level * (max_level - prev_max_level)
+                )
+                prev_max_level = max_level
+        return 0.0
 
     def get_iv_percentage(self):
         return ((self.individual_attack + self.individual_stamina + self.individual_defense + 0.0) / 45.0) * 100.0


### PR DESCRIPTION
this is no new bot functionality, just more available info for devs

with this PR i provide you with the actual pokemon levels, derived from their CPM value

in addition i created iv_normalized which is usually close the the previous IV, except it is also calculated when we do net get IV values from the server (thus safer to use in filters).
difference is it's derived from the CP value and pokemons CPM. this means the iv value attack is prioritized and results in higher-iv than the other iv's.

then i also changed max_cp calculation to actually reflect the max cp of this individual pokemon

hope you like it, now i can work more on the release cycle


nearly forgot: i removed the previous pokemon 'score', caus it was and not used anywhere and non accurate anyway