### PR TITLE
Use Razz Berry (after failed attempt(s)) to increase chances of capturing Pokemon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ optional arguments:
     * `SPIN_ALL_FORTS` [Experimental] will try to route using google maps(must have key) to all visible forts, if `SKIP_VISITED_FORT_DURATION` is set high enough, you may roam around forever.
     * `KEEP_POKEMON_IDS` IDs of pokemon you want the bot to hold regardless of IV/CP
     * `CATCH_POKEMON` Allows you to disabling catching pokemon if you just want to mine for the forts for pokeballs
+    * `CAPTURE`
+     * `MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY` mininum number of failed capture attempts before trying to use a Razz Berry (default: 1)
     * `EGG_INCUBATION`
      * `ENABLE` enables automatic use of incubators (default: true)
      * `USE_DISPOSABLE_INCUBATORS` enables use of disposable (3-times use) incubators (default: false)
@@ -60,6 +62,7 @@ optional arguments:
      * `FARM_IGNORE_POKEBALL_COUNT`: `Boolean`, Whether to include this ball in counting. Same goes for `GREATBALL`, `ULTRABALL`, and `MASTERBALL`. Masterball is ignored by default.
      * `FARM_OVERRIDE_STEP_SIZE`: `Integer`, When it goes into farming mode, the bot assumes this step size to potentially speed up resource gathering. _This might lead to softbans._ Setting to `-1` disables this feature. Disabled by default for safety.
      * If `EXPERIMENTAL` OR `CATCH_POKEMON` are false, this configuration will disable itself.
+
 
 ## Requirements
  * Run `pip install -r requirements.txt`

--- a/config.json.example
+++ b/config.json.example
@@ -15,6 +15,9 @@
       "SPIN_ALL_FORTS": true,
       "STAY_WITHIN_PROXIMITY": 9999,
       "AUTO_USE_LUCKY_EGG": false,
+      "CAPTURE": {
+        "MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY": 1
+      },
       "EGG_INCUBATION": {
         "ENABLE": true,
         "USE_DISPOSABLE_INCUBATORS": false,

--- a/config.json.example
+++ b/config.json.example
@@ -16,7 +16,7 @@
       "STAY_WITHIN_PROXIMITY": 9999,
       "AUTO_USE_LUCKY_EGG": false,
       "CAPTURE": {
-        "MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY": 1
+        "MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY": 3
       },
       "EGG_INCUBATION": {
         "ENABLE": true,

--- a/pgoapi/inventory.py
+++ b/pgoapi/inventory.py
@@ -17,6 +17,8 @@ class Inventory:
         self.super_potion = 0
         self.max_potion = 0
         self.lucky_eggs = 0
+        self.razz_berries = 0
+
         self.pokemon_candy = defaultdict()
         self.eggs_available = []
         self.incubators_available = []
@@ -46,6 +48,8 @@ class Inventory:
                 self.ultra_balls = item_count
             elif item_id == Inventory_Enum.ITEM_LUCKY_EGG:
                 self.lucky_eggs = item_count
+            elif item_id == Inventory_Enum.ITEM_RAZZ_BERRY:
+                self.razz_berries = item_count
             pokemon_family = inventory_item['inventory_item_data'].get('pokemon_family', {})
             self.pokemon_candy[pokemon_family.get('family_id', -1)] = pokemon_family.get('candy', -1)
             pokemon_data = inventory_item['inventory_item_data'].get('pokemon_data', {})
@@ -106,6 +110,16 @@ class Inventory:
         else:
             return Inventory_Enum.ITEM_MASTER_BALL
 
+    def take_ball(self, ball_id):
+        if ball_id == Inventory_Enum.ITEM_POKE_BALL:
+            self.poke_balls -= 1
+        elif ball_id == Inventory_Enum.ITEM_GREAT_BALL:
+            self.great_balls -= 1
+        elif ball_id == Inventory_Enum.ITEM_ULTRA_BALL:
+            self.ultra_balls -= 1
+        elif ball_id == Inventory_Enum.ITEM_MASTER_BALL:
+            self.master_balls -= 1
+
     def has_lucky_egg(self):
         for inventory_item in self.inventory_items:
             item = inventory_item['inventory_item_data'].get('item', {})
@@ -118,19 +132,22 @@ class Inventory:
         self.lucky_eggs -= 1
         return Inventory_Enum.ITEM_LUCKY_EGG
 
-    def take_ball(self, ball_id):
-        if ball_id == Inventory_Enum.ITEM_POKE_BALL:
-            self.poke_balls -= 1
-        elif ball_id == Inventory_Enum.ITEM_GREAT_BALL:
-            self.great_balls -= 1
-        elif ball_id == Inventory_Enum.ITEM_ULTRA_BALL:
-            self.ultra_balls -= 1
-        elif ball_id == Inventory_Enum.ITEM_MASTER_BALL:
-            self.master_balls -= 1
+    def has_berry(self):
+        # Only Razz berries are in the game at the moment
+        for inventory_item in self.inventory_items:
+            item = inventory_item['inventory_item_data'].get('item', {})
+            item_id = item.get('item_id', -1)
+            if item_id == Inventory_Enum.ITEM_RAZZ_BERRY:
+                return True
+        return False
+
+    def take_berry(self):
+        self.razz_berries -= 1
+        return Inventory_Enum.ITEM_RAZZ_BERRY
 
     def __str__(self):
         return "PokeBalls: {0}, GreatBalls: {1}, MasterBalls: {2}, UltraBalls: {3} \n " \
-               "Potion: {4}, Super Potion: {5}, Max Potion {6}, Hyper Potion {7}, Lucky Eggs {8}".format(self.poke_balls,
+               "Potion: {4}, Super Potion: {5}, Max Potion {6}, Hyper Potion {7}, Lucky Eggs {8}, Razz Berries {9}".format(self.poke_balls,
                                                                                         self.great_balls,
                                                                                         self.master_balls,
                                                                                         self.ultra_balls,
@@ -138,7 +155,8 @@ class Inventory:
                                                                                         self.super_potion,
                                                                                         self.max_potion,
                                                                                         self.hyper_potion,
-                                                                                        self.lucky_eggs)
+                                                                                        self.lucky_eggs,
+                                                                                        self.razz_berries)
 
     def __repr__(self):
         return self.__str__()

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -532,10 +532,10 @@ class PGoApi:
             item_capture_mult = 1.0
 
             # Try to use a berry to increase the chance of catching the pokemon when we have failed enough attempts
-            if catch_attempts > self.config.get("CAPTURE", {}).get("MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY", 1) and self.inventory.has_berry():
+            if catch_attempts > self.config.get("CAPTURE", {}).get("MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY", 3) and self.inventory.has_berry():
                 self.log.info("Feeding da razz berry!")
                 r = self.use_item_capture(item_id=self.inventory.take_berry(), encounter_id=encounter_id, spawn_point_id=spawn_point_id).call()['responses']['USE_ITEM_CAPTURE']
-                if "success" in r:
+                if r.get("success", False):
                     item_capture_mult = r.get("item_capture_mult", 1.0)
                 else:
                     self.log.info("Could not feed the Pokemon. (%s)", r)


### PR DESCRIPTION
This feature gives the ability to feed Razz Berries to the Pokemon to increase the chances of capture when the previous attempt(s) failed (1.5x multiplier). The minimum number of failed attempts before using the berry is configurable in the configuration file:

```
CAPTURE: {
    MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY: 1
}
```