### PR TITLE
Fix slack link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,12 @@ Put them in config. Type exactly as the name appears
 What's working:
  * A lot of things. Check out the example config to see some of the features. Catching Lured pokemon, regular pokemon, multiple kinds of navigation (google maps, walking, driving, customized speed), a web ui, auto transfers, auto evolves, auto power ups, auto egg incubation, inventory managament, multiple account botting. And much more, README to be updated soon
 
-## Chatting with us:
-We're hanging out at the [Pokemon GO Reverse Engineering team on Slack](https://pkre.slack.com). [Need an invite?](https://shielded-earth-81203.herokuapp.com/)
+---
+
+### Join slack channel:
+  To ask question  related  to api and general help, join Pokemon Go Reverse Engineering Slack team. 
+ * To join, get a invite from [here](https://shielded-earth-81203.herokuapp.com/) , join team via the email you recieve and then signin [here](https://pkre.slack.com).
+
 
 ## Credits
 * [tejado](https://github.com/tejado) for the base of this


### PR DESCRIPTION
Looks like the copy was changed for the Slack link, and in the process the Slack link was broken.

(Broken link is on master/README.md)