### PR TITLE
Minor change: Link fix for slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ What's working:
 
 ### Join slack channel:
   To ask question  related  to api and general help, join Pokemon Go Reverse Engineering Slack team. 
- * To join, get a invite from [here](https://shielded-earth-81203.herokuapp.com/) , join team via the email you recieve and then signin [here](pkre.slack.com).
+ * To join, get a invite from [here](https://shielded-earth-81203.herokuapp.com/) , join team via the email you recieve and then signin [here](https://pkre.slack.com).
 
  
 ## Credits


### PR DESCRIPTION
The older link was redirecting to https://github.com/j-e-k/poketrainer/blob/master/pkre.slack.com.
Fixed it.