### PR TITLE
Bugfix: start_km_walked is not always set

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -859,15 +859,23 @@ class PGoApi:
         if not self.EGG_INCUBATION_ENABLED:
             return
         if self.player_stats.km_walked > 0:
+            incubator_start_km_walked = self.player_stats.km_walked
+
             for incubator in self.inventory.incubators_busy:
-                incubator_egg_distance = incubator['target_km_walked'] - incubator['start_km_walked']
-                incubator_distance_done = self.player_stats.km_walked - incubator['start_km_walked']
+                if 'start_km_walked' in incubator:
+                    incubator_start_km_walked = incubator['start_km_walked']
+
+                incubator_egg_distance = incubator['target_km_walked'] - incubator_start_km_walked
+                incubator_distance_done = self.player_stats.km_walked - incubator_start_km_walked
                 if incubator_distance_done > incubator_egg_distance:
                     self.attempt_finish_incubation()
                     break
             for incubator in self.inventory.incubators_busy:
-                incubator_egg_distance = incubator['target_km_walked'] - incubator['start_km_walked']
-                incubator_distance_done = self.player_stats.km_walked - incubator['start_km_walked']
+                if 'start_km_walked' in incubator:
+                    incubator_start_km_walked = incubator['start_km_walked']
+
+                incubator_egg_distance = incubator['target_km_walked'] - incubator_start_km_walked
+                incubator_distance_done = self.player_stats.km_walked - incubator_start_km_walked
                 self.log.info('Incubating %skm egg, %skm done', incubator_egg_distance,
                               round(incubator_distance_done, 2))
         for incubator in self.inventory.incubators_available:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -859,11 +859,8 @@ class PGoApi:
         if not self.EGG_INCUBATION_ENABLED:
             return
         if self.player_stats.km_walked > 0:
-            incubator_start_km_walked = self.player_stats.km_walked
-
             for incubator in self.inventory.incubators_busy:
-                if 'start_km_walked' in incubator:
-                    incubator_start_km_walked = incubator['start_km_walked']
+                incubator_start_km_walked = incubator.get('start_km_walked', self.player_stats.km_walked)
 
                 incubator_egg_distance = incubator['target_km_walked'] - incubator_start_km_walked
                 incubator_distance_done = self.player_stats.km_walked - incubator_start_km_walked
@@ -871,8 +868,7 @@ class PGoApi:
                     self.attempt_finish_incubation()
                     break
             for incubator in self.inventory.incubators_busy:
-                if 'start_km_walked' in incubator:
-                    incubator_start_km_walked = incubator['start_km_walked']
+                incubator_start_km_walked = incubator.get('start_km_walked', self.player_stats.km_walked)
 
                 incubator_egg_distance = incubator['target_km_walked'] - incubator_start_km_walked
                 incubator_distance_done = self.player_stats.km_walked - incubator_start_km_walked


### PR DESCRIPTION
For some reason the start_km_walked key is not always set. This fixed that by setting it to the currently walked amount of km. In my cause it caused the bot to try (and successfully) hatch the egg.