### PR TITLE
Update pokemon.html

### DIFF
--- a/templates/pokemon.html
+++ b/templates/pokemon.html
@@ -45,7 +45,7 @@
           <div class="container-fluid">
             Level XP: {{player["level_xp"]}} / {{player["goal_xp"]}}
             <div class="progress">
-              <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{ (player["experience"] / player["next_level_xp"] * 100)|int }}%;">
+              <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: { (player["level_xp"] / player["goal_xp"] * 100)|int }}%;">
                 {{ (player["level_xp"] / player["goal_xp"] * 100)|int }}%
               </div>
             </div>


### PR DESCRIPTION
Fixed bug with level XP progress bar where text was %XP gained this level for next level, but value was %XP total for next level.

![image](https://cloud.githubusercontent.com/assets/1432270/17269177/d308d4e8-55f6-11e6-9294-75ecd82af892.png)

Eg. The text might say '46%' as you were near halfway through a level, but the bar would be closer to 85% as your current XP was 85% of the total needed for the next level.