### PR TITLE
add automatic Travis CI build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+    - 2.7
+
+install:
+    - pip install tox-travis
+
+script:
+    - tox
+
+sudo: false

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 ----
 
+[![Build Status](https://travis-ci.org/infinitewarp/poketrainer.svg?branch=travis)](https://travis-ci.org/infinitewarp/poketrainer)
+
+
  #### Rename `config.json.example` to `config.json`
 ```
 usage: python pokecli.py [-h] [-i CONFIG_INDEX] [-l LOCATION] [-d]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = python27
+envlist = py27
 
 [testenv]
 commands =


### PR DESCRIPTION
We should be running builds on [Travis CI](https://travis-ci.org)! 🎉 

This basic config runs `tox` on Travis CI. I would love to see us add some smoke tests around the code too, and those would also run on Travis after updating `.travis.yml`. This commit adds a status button to the top of `README.md`. Of course, if you merge this, you'll probably want to set up your own account on Travis and change that link to your account.

https://travis-ci.org/infinitewarp/poketrainer

[![Build Status](https://travis-ci.org/infinitewarp/poketrainer.svg?branch=travis)](https://travis-ci.org/infinitewarp/poketrainer)
