### PR TITLE
Allows manual entry of which pokeball to try and use, updates web interface to allow evolving the same way as transferring

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -22,10 +22,10 @@
         "CATCH_POKEMON": true,
         "MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY": 3,
         "MAX_CATCH_ATTEMPTS": 10,
-        "use_pokeball_at": 15,
-        "use_greatball_at": 15,
-        "use_ultraball_at": 15,
-        "use_masterball_at": 0
+        "USE_POKEBALL_IF_PERCENT": 15,
+        "USE_GREATBALL_IF_PERCENT": 15,
+        "USE_ULTRABALL_IF_PERCENT": 15,
+        "USE_MASTERBALL": false
       },
       "EGG_INCUBATION": {
         "ENABLE": true,

--- a/config.json.example
+++ b/config.json.example
@@ -21,7 +21,11 @@
       "CAPTURE": {
         "CATCH_POKEMON": true,
         "MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY": 3,
-        "MAX_CATCH_ATTEMPTS": 10
+        "MAX_CATCH_ATTEMPTS": 10,
+        "use_pokeball_at": 15,
+        "use_greatball_at": 15,
+        "use_ultraball_at": 15,
+        "use_masterball_at": 0
       },
       "EGG_INCUBATION": {
         "ENABLE": true,

--- a/pgoapi/inventory.py
+++ b/pgoapi/inventory.py
@@ -20,7 +20,7 @@ class Inventory:
         self.pokeball_percent = (percentages[0] / 100)
         self.greatball_percent = (percentages[1] / 100)
         self.ultraball_percent = (percentages[2] / 100)
-        self.masterball_percent = (percentages[3] / 100)
+        self.use_masterball = (percentages[3])
 
         self.pokemon_candy = defaultdict()
         self.eggs_available = []
@@ -81,7 +81,7 @@ class Inventory:
         self.ultra_balls -= 1
 
     def best_ball(self):
-        if self.masterball_percent > 0 and self.master_balls:
+        if self.use_masterball == true and self.master_balls:
             return Inventory_Enum.ITEM_MASTER_BALL
         elif self.ultra_balls:
             return Inventory_Enum.ITEM_ULTRA_BALL

--- a/pgoapi/inventory.py
+++ b/pgoapi/inventory.py
@@ -5,7 +5,7 @@ from pgoapi.protos.POGOProtos.Inventory import Item_pb2 as Inventory_Enum
 
 
 class Inventory:
-    def __init__(self, inventory_items):
+    def __init__(self, percentages, inventory_items):
         self.inventory_items = inventory_items
         self.ultra_balls = 0
         self.great_balls = 0
@@ -17,6 +17,10 @@ class Inventory:
         self.max_potion = 0
         self.lucky_eggs = 0
         self.razz_berries = 0
+        self.pokeball_percent = (percentages[0] / 100)
+        self.greatball_percent = (percentages[1] / 100)
+        self.ultraball_percent = (percentages[2] / 100)
+        self.masterball_percent = (percentages[3] / 100)
 
         self.pokemon_candy = defaultdict()
         self.eggs_available = []
@@ -77,7 +81,7 @@ class Inventory:
         self.ultra_balls -= 1
 
     def best_ball(self):
-        if self.master_balls:
+        if self.masterball_percent > 0 and self.master_balls:
             return Inventory_Enum.ITEM_MASTER_BALL
         elif self.ultra_balls:
             return Inventory_Enum.ITEM_ULTRA_BALL
@@ -89,18 +93,15 @@ class Inventory:
     # FIXME make not bad, this should be configurable
     def take_next_ball(self, capture_probability):
         if self.can_attempt_catch():
-            if capture_probability.get(Inventory_Enum.ITEM_POKE_BALL, 0) > 0.15 and self.poke_balls:
+            if capture_probability.get(Inventory_Enum.ITEM_POKE_BALL, 0) > self.pokeball_percent and self.poke_balls:
                 self.take_pokeball()
                 return Inventory_Enum.ITEM_POKE_BALL
-            elif capture_probability.get(Inventory_Enum.ITEM_GREAT_BALL, 0) > 0.15 and self.great_balls:
+            elif capture_probability.get(Inventory_Enum.ITEM_GREAT_BALL, 0) > self.greatball_percent and self.great_balls:
                 self.take_greatball()
                 return Inventory_Enum.ITEM_GREAT_BALL
-            elif capture_probability.get(Inventory_Enum.ITEM_ULTRA_BALL, 0) > 0.15 and self.ultra_balls:
+            elif capture_probability.get(Inventory_Enum.ITEM_ULTRA_BALL, 0) > self.ultraball_percent and self.ultra_balls:
                 self.take_ultraball()
                 return Inventory_Enum.ITEM_ULTRA_BALL
-            elif capture_probability.get(Inventory_Enum.ITEM_MASTER_BALL, 0) > 0.15 and self.master_balls:
-                self.take_masterball()
-                return Inventory_Enum.ITEM_MASTER_BALL
             else:
                 best_ball = self.best_ball()
                 self.take_ball(self.best_ball())

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -90,11 +90,11 @@ class PGoApi:
         self._farm_mode_triggered = False
         self._orig_step_size = config.get("BEHAVIOR", {}).get("STEP_SIZE", 200)
         self.wander_steps = config.get("BEHAVIOR", {}).get("WANDER_STEPS", 0)
-        pokeball_percent = config.get("CAPTURE", {}).get("use_pokeball_at", 15)
-        greatball_percent = config.get("CAPTURE", {}).get("use_greatball_at", 15)
-        ultraball_percent = config.get("CAPTURE", {}).get("use_ultraball_at", 15)
-        masterball_percent = config.get("CAPTURE", {}).get("use_masterball_at", 0)
-        self.percentages = [pokeball_percent, greatball_percent, ultraball_percent, masterball_percent]
+        pokeball_percent = config.get("CAPTURE", {}).get("USE_POKEBALL_IF_PERCENT", 15)
+        greatball_percent = config.get("CAPTURE", {}).get("USE_GREATBALL_IF_PERCENT", 15)
+        ultraball_percent = config.get("CAPTURE", {}).get("USE_ULTRABALL_IF_PERCENT", 15)
+        use_masterball = config.get("CAPTURE", {}).get("USE_MASTERBALL", false)
+        self.percentages = [pokeball_percent, greatball_percent, ultraball_percent, use_masterball]
 
         self.pokemon_caught = 0
         self.player = Player({})

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -423,10 +423,11 @@ class PGoApi:
             if self.LIST_POKEMON_BEFORE_CLEANUP:
                 self.log.info(get_inventory_data(res, self.player_stats.level, self.SCORE_METHOD, self.SCORE_SETTINGS))
             self.incubate_eggs()
-            self.attempt_evolve(self.inventory.inventory_items)
-            self.cleanup_pokemon(self.inventory.inventory_items)
             # Auto-use lucky-egg if applicable
             self.use_lucky_egg()
+            self.attempt_evolve(self.inventory.inventory_items)
+            self.cleanup_pokemon(self.inventory.inventory_items)
+
 
             # Farm precon
             if self.FARM_ITEMS_ENABLED:


### PR DESCRIPTION
This changes ```take_next_ball``` to look at the values in config.json
to decide when to switch to another ball. Because masterballs should in
theory always catch a pokemon, I disabled it by default. Setting
```use_masterball_at``` to anything other than 0 will result in an
attempt to use a masterball if the ultraball % isn’t met. If this is
set to 0 and ultraball % still isn’t met, ```get_best_ball``` will
return an ultraball.