### PR TITLE
Make use of self.visited_forts non-experimental

### DIFF
--- a/pgoapi/location.py
+++ b/pgoapi/location.py
@@ -81,9 +81,8 @@ def distance_in_meters(p1, p2):
     return vincenty(p1, p2).meters
 
 
-def filtered_forts(starting_location, origin, forts, proximity, visited_forts={}, experimental=False, reverse=False):
-    forts = filter(lambda f: is_active_pokestop(f[0], experimental=experimental,
-                                                visited_forts=visited_forts, starting_location=starting_location,
+def filtered_forts(starting_location, origin, forts, proximity, visited_forts={}, reverse=False):
+    forts = filter(lambda f: is_active_pokestop(f[0], visited_forts=visited_forts, starting_location=starting_location,
                                                 proximity=proximity),
                    map(lambda x: (x, distance_in_meters(origin, (x['latitude'], x['longitude']))), forts))
 
@@ -91,20 +90,14 @@ def filtered_forts(starting_location, origin, forts, proximity, visited_forts={}
     return sorted_forts
 
 
-def is_active_pokestop(fort, experimental, visited_forts, starting_location, proximity):
+def is_active_pokestop(fort, visited_forts, starting_location, proximity):
     is_active_fort = fort.get('type', None) == 1 and ("enabled" in fort or 'lure_info' in fort) and fort.get(
         'cooldown_complete_timestamp_ms', -1) < time() * 1000
-    if experimental and visited_forts:
-        if proximity and proximity > 0:
-            return is_active_fort and fort['id'] not in visited_forts and distance_in_meters(starting_location, (
-                fort['latitude'], fort['longitude'])) < proximity
-        else:
-            return is_active_fort and fort['id'] not in visited_forts
     if proximity and proximity > 0:
-        return is_active_fort and distance_in_meters(starting_location,
-                                                     (fort['latitude'], fort['longitude'])) < proximity
+        return is_active_fort and fort['id'] not in visited_forts and distance_in_meters(starting_location, (
+            fort['latitude'], fort['longitude'])) < proximity
     else:
-        return is_active_fort
+        return is_active_fort and fort['id'] not in visited_forts
 
 
 # from pokemongodev slack @erhan

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -528,8 +528,7 @@ class PGoApi:
     def spin_nearest_fort(self):
         map_cells = self.nearby_map_objects()['responses'].get('GET_MAP_OBJECTS', {}).get('map_cells', [])
         forts = PGoApi.flatmap(lambda c: c.get('forts', []), map_cells)
-        destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts,
-                                      self.experimental)
+        destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts)
         if destinations:
             nearest_fort = destinations[0][0]
             nearest_fort_dis = destinations[0][1]
@@ -590,8 +589,7 @@ class PGoApi:
         res = self.nearby_map_objects()
         map_cells = res['responses'].get('GET_MAP_OBJECTS', {}).get('map_cells', [])
         forts = PGoApi.flatmap(lambda c: c.get('forts', []), map_cells)
-        destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts,
-                                      self.experimental)
+        destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts)
         if not destinations:
             self.log.debug("No fort to walk to! %s", res)
             self.log.info('No more spinnable forts within proximity. Or server error')
@@ -623,8 +621,7 @@ class PGoApi:
         res = self.nearby_map_objects()
         map_cells = res['responses'].get('GET_MAP_OBJECTS', {}).get('map_cells', [])
         forts = PGoApi.flatmap(lambda c: c.get('forts', []), map_cells)
-        destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts,
-                                      self.experimental)
+        destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts)
         if not destinations:
             self.log.debug("No fort to walk to! %s", res)
             self.log.info('No more spinnable forts within proximity. Returning back to origin')


### PR DESCRIPTION
This will make the use of self.visited_forts non-experimental, essentially enabling the current fix for the rate-limit for users running without experimental features.

Keep in mind there seem to be other rate-limits, noticably with catching pokemons, that are not fixed yet. They are not that impactful though.