### PR TITLE
Fix Dockerfile to include listener.py

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -5,6 +5,7 @@ COPY requirements.txt /
 COPY container/launch.sh /
 COPY ./pokecli.py /
 COPY ./web.py /
+COPY ./listener.py /
 COPY GAME_MASTER_POKEMON_v0_2.tsv /
 COPY GAME_ATTACKS_v0_1.tsv /
 COPY pokemon.en.json /


### PR DESCRIPTION
Created pull request to fix issue #375, not including listener.py in the docker file. Resolved my issue (yesterday) of trying to run develop, now that it's in master, this really should be fixed. 