### PR TITLE
Caching forts, saving + loading cache, spin cached forts

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -2,69 +2,91 @@
   "accounts": [
     {
       "auth_service": "google",
-      "username": "test@gmail.com",
-      "password": "password",
-      "location": "University of Southern California, Los Angeles, CA",
+      "username": "@gmail.com",
+      "password": "",
+      "location": "32.714627, -117.162521",
       "GMAPS_API_KEY": "some api key here",
       "BEHAVIOR": {
-        "USE_GOOGLE": true,
-        "STEP_SIZE": 100,
-        "WANDER_STEPS": 0,
-        "EXPERIMENTAL": false,
-        "SKIP_VISITED_FORT_DURATION": 600,
+        "USE_GOOGLE": false,
+        "STEP_SIZE": 150,
+        "WANDER_STEPS": 20,
+        "EXPERIMENTAL": true,
+        "SKIP_VISITED_FORT_DURATION": 300,
         "SPIN_ALL_FORTS": true,
-        "STAY_WITHIN_PROXIMITY": 9999,
+        "STAY_WITHIN_PROXIMITY": 725,
         "AUTO_USE_LUCKY_EGG": false,
-        "EXTRA_WAIT" : 0.2,
-        "SLEEP_MULT" : 1.0
+        "EXTRA_WAIT" : 0.0,
+        "SLEEP_MULT" : 0.0,
+        "USE_CACHED_FORTS" : true,
+        "CACHED_FORTS_SORTED" : false
       },
       "CAPTURE": {
         "CATCH_POKEMON": true,
-        "MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY": 3,
-        "MAX_CATCH_ATTEMPTS": 10,
-        "USE_POKEBALL_IF_PERCENT": 15,
-        "USE_GREATBALL_IF_PERCENT": 15,
-        "USE_ULTRABALL_IF_PERCENT": 15,
-        "USE_MASTERBALL": false
+        "MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY": 1,
+        "MAX_CATCH_ATTEMPTS": 10
       },
       "EGG_INCUBATION": {
         "ENABLE": true,
-        "USE_DISPOSABLE_INCUBATORS": false,
+        "USE_DISPOSABLE_INCUBATORS": true,
         "BIG_EGGS_FIRST": true
       },
       "POKEMON_EVOLUTION": {
         "PIDGEY": 12,
-        "WEEDLE": 12
+        "WEEDLE": 12,
+        "CATERPIE": 12,
+        "RATTATA": 25,
+        "ABRA": 25,
+        "GEODUDE": 25,
+        "EKANS": 50,
+        "PIKACHU": 50,
+        "SANDSHREW": 50,
+        "CLEFAIRY": 50,
+        "VULPIX": 50,
+        "JIGGLYPUFF": 50,
+        "ZUBAT": 50,
+        "PARAS": 50,
+        "VENONAT": 50,
+        "DIGLETT": 50,
+        "MEOWTH": 50,
+        "PSYDUCK": 50,
+        "MANKEY": 50,
+        "GROWLITHE": 50,
+        "TENTACOOL": 50,
+        "PONYTA": 50,
+        "SLOWPOKE": 50,
+        "MAGNEMITE": 50,
+        "DODUO": 50,
+        "SEEL": 50,
+        "GRIMER": 50,
+        "SHELLDER": 50,
+        "DROWZEE": 50,
+        "KRABBY": 50,
+        "VOLTORB": 50,
+        "EXEGGCUTE": 50,
+        "CUBONE": 50,
+        "KOFFING": 50,
+        "RHYHORN": 50,
+        "HORSEA": 50,
+        "GOLDEEN": 50,
+        "STARYU": 50,
+        "OMANYTE": 50,
+        "KABUTO": 50
       },
       "POKEMON_CLEANUP": {
         "MIN_SIMILAR_POKEMON": 1,
         "MAX_SIMILAR_POKEMON": 999,
-        "KEEP_POKEMON_NAMES": ["MEWTWO"],
-        "THROW_POKEMON_NAMES": ["PIDGEY"],
+        "KEEP_POKEMON_NAMES": ["MEWTWO","SNORLAX","LAPRAS","DRAGONITE","VAPOREON","SLOWBRO","GOLEM","MUK","EXEGGUTOR","CHARIZARD","VENUSAUR","BLASTOISE"],
+        "THROW_POKEMON_NAMES": ["RATTATA"],
         "RELEASE_METHOD": "CLASSIC",
         "RELEASE_METHOD_CLASSIC": {
-          "KEEP_CP_OVER": 500,
-          "KEEP_IV_OVER": 50
+          "KEEP_CP_OVER": 1000,
+          "KEEP_IV_OVER": 95,
+          "KEEP_IV_ONLY_WITH_PERCENT_CP": 0,
+          "MAX_POKEMON_HIGH_IV": 999
         },
         "RELEASE_METHOD_DUPLICATES": {
           "RELEASE_DUPLICATES_MAX_SCORE": 1000,
           "RELEASE_DUPLICATES_SCALAR": 0.9
-        },
-        "RELEASE_METHOD_ADVANCED": {
-          "ALWAYS_RELEASE_BELOW_LEVEL": 0,
-          "KEEP_CP_OVER": 1000,
-          "KEEP_IV_OVER": 90,
-          "BEST_CP": {
-            "MIN_AMOUNT": 1,
-            "KEEP_ADDITIONAL_SCALAR": 1.0,
-            "MAX_AMOUNT": 999
-          },
-          "BEST_IV": {
-            "MIN_AMOUNT": 1,
-            "KEEP_ADDITIONAL_SCALAR": 1.0,
-            "MAX_AMOUNT": 999,
-            "IGNORE_BELOW": 50
-          }
         },
         "SCORE_METHOD": "CP",
         "SCORE_METHOD_FANCY": {
@@ -73,16 +95,18 @@
         }
       },
       "MIN_ITEMS": {
-        "ITEM_POTION": 5,
-        "ITEM_SUPER_POTION": 5,
-        "ITEM_HYPER_POTION": 10,
-        "ITEM_MAX_POTION": 20,
-        "ITEM_POKE_BALL": 100,
-        "ITEM_GREAT_BALL": 50,
-        "ITEM_ULTRA_BALL": 30,
-        "ITEM_RAZZ_BERRY": 10,
-        "ITEM_REVIVE": 5,
-        "ITEM_MAX_REVIVE": 10
+        "ITEM_POKE_BALL": 30,
+        "ITEM_GREAT_BALL": 100,
+        "ITEM_ULTRA_BALL": 300,
+        "ITEM_POTION": 1,
+        "ITEM_SUPER_POTION": 1,
+        "ITEM_HYPER_POTION": 1,
+        "ITEM_MAX_POTION": 300,
+        "ITEM_BLUK_BERRY": 10,
+        "ITEM_NANAB_BERRY": 10,
+        "ITEM_REVIVE": 1,
+        "ITEM_MAX_REVIVE": 50,
+        "ITEM_RAZZ_BERRY": 100
       },
       "NEEDY_ITEM_FARMING": {
         "ENABLE": false,

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -176,6 +176,7 @@ class PGoApi:
         self.should_catch_pokemon = config.get("CAPTURE", {}).get("CATCH_POKEMON", True)
         self.max_catch_attempts = config.get("CAPTURE", {}).get("MAX_CATCH_ATTEMPTS", 10)
 
+        self.new_forts = []
         self.cache_filename = './cache/cache ' + str(config["location"]) + str(self.STAY_WITHIN_PROXIMITY)
         self.all_cached_forts = []
         self.spinnable_cached_forts = []

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -34,7 +34,10 @@ import logging
 from collections import defaultdict
 from itertools import chain
 from time import time
-
+import sys
+import os
+import copy
+import pickle
 import gevent
 import six
 from cachetools import TTLCache
@@ -172,6 +175,13 @@ class PGoApi:
         self.STAY_WITHIN_PROXIMITY = config.get("BEHAVIOR", {}).get("STAY_WITHIN_PROXIMITY", 9999999)  # Stay within proximity
         self.should_catch_pokemon = config.get("CAPTURE", {}).get("CATCH_POKEMON", True)
         self.max_catch_attempts = config.get("CAPTURE", {}).get("MAX_CATCH_ATTEMPTS", 10)
+
+        self.cache_filename = './cache/cache ' + str(config["location"]) + str(self.STAY_WITHIN_PROXIMITY)
+        self.all_cached_forts = []
+        self.spinnable_cached_forts = []
+        self.use_cache = self.config.get("BEHAVIOR", {}).get("USE_CACHED_FORTS", False)
+        self.cache_is_sorted = self.config.get("BEHAVIOR", {}).get("CACHED_FORTS_SORTED", False)
+        self.visited_cache_forts = TTLCache(maxsize=120, ttl=config.get("BEHAVIOR", {}).get("SKIP_VISITED_FORT_DURATION", 600))
 
         # Sanity checking
         self.FARM_ITEMS_ENABLED = self.FARM_ITEMS_ENABLED and self.experimental and self.should_catch_pokemon  # Experimental, and we needn't do this if we're farming anyway
@@ -529,6 +539,7 @@ class PGoApi:
         forts = PGoApi.flatmap(lambda c: c.get('forts', []), map_cells)
         destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts)
         if destinations:
+            self.new_forts = destinations
             nearest_fort = destinations[0][0]
             nearest_fort_dis = destinations[0][1]
             self.log.info("Nearest fort distance is {0:.2f} meters".format(nearest_fort_dis))
@@ -597,6 +608,8 @@ class PGoApi:
             self.log.info('No more spinnable forts within proximity. Or server error')
             self.walk_back_to_origin()
             return False
+
+        self.new_forts = destinations
         if len(destinations) >= 20:
             destinations = destinations[:20]
         furthest_fort = destinations[0][0]
@@ -630,6 +643,7 @@ class PGoApi:
             self.walk_back_to_origin()
             return False
 
+        self.new_forts = destinations
         for fort_data in destinations:
             self.walk_to_fort(fort_data)
 
@@ -1104,6 +1118,112 @@ class PGoApi:
             self.update_player_inventory()
             return False
 
+    def cache_forts(self, forts):
+        if not self.all_cached_forts:
+            with open(self.cache_filename,'wb') as handle:
+                 pickle.dump(forts, handle)
+
+            with open(self.cache_filename,'rb') as handle:
+                self.all_cached_forts = pickle.load(handle)
+
+            self.log.info("Cache was empty... Dumping in new forts and initializing all_cached_forts")
+
+        else:
+            for fort in forts:
+                #for subcache in self.all_cached_forts:
+                #if fort[0]['id'] not in self.all_cached_forts:
+                if not any(fort[0]['id'] == x[0]['id'] for x in self.all_cached_forts):
+                    #if fort[0]['id'] and subcache[0]['id'] and fort[0]['id'] == subcache[0]['id']:
+                    self.all_cached_forts.insert(0,fort)
+                    self.log.info("Added new fort to cache")
+
+            with open(self.cache_filename,'wb') as handle:
+                 pickle.dump(self.all_cached_forts, handle)
+
+        self.log.info("Cached forts %s: ", len(self.all_cached_forts))
+
+    def setup_cache(self):
+        try:
+            self.log.debug("Opening cache file...")
+            with open(self.cache_filename,'rb') as handle:
+                self.all_cached_forts = pickle.load(handle)
+
+        except Exception as e:
+            self.log.debug("Could not find or open cache, making new cache...")
+
+            try:
+                os.remove(self.cache_filename)
+            except OSError:
+                pass
+            with open(self.cache_filename,'wb') as handle:
+                 pickle.dump(self.all_cached_forts, handle)
+
+    def sort_cached_forts(self):
+        if not self.cache_is_sorted:
+            self.log.info("Cache is unsorted, sorting now...")
+            tempallcached = copy.deepcopy(self.all_cached_forts) #copy over original
+            tempsorted = [copy.deepcopy(tempallcached[0])] #the final list to copy to cache
+            tempelement = copy.deepcopy(tempallcached[0]) #cur element
+            tempbool = True
+
+            while (len(tempsorted) < len(self.all_cached_forts)): #sort all elements
+                templastelement = copy.deepcopy(tempsorted[-1])
+                tempelement = copy.deepcopy(tempsorted[0])
+                tempmaxfloat = sys.float_info.max #start with max float to find min distance
+
+                if(tempbool):
+                    for fort in tempallcached:
+                        if distance_in_meters((self._origPosF[0], self._origPosF[1]),
+                        (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat:
+                            tempelement = copy.deepcopy(fort)
+                            tempmaxfloat = distance_in_meters((self._origPosF[0], self._origPosF[1]),
+                            (fort[0]['latitude'], fort[0]['longitude']))
+
+                    tempsorted.pop(0)
+                    tempsorted.append(tempelement)
+                    tempallcached.remove(tempelement)
+                    tempbool = False
+                else:
+                    for fort in tempallcached:
+                        if ((distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
+                        (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat)
+                        and (not any(fort[0]['id'] == x[0]['id'] for x in tempsorted))):
+                            tempelement = copy.deepcopy(fort)
+                            tempmaxfloat = distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
+                            (fort[0]['latitude'], fort[0]['longitude']))
+                    tempallcached.remove(tempelement)
+                    tempsorted.append(tempelement)
+
+            self.spinnable_cached_forts = copy.deepcopy(tempsorted)
+            self.cache_is_sorted = True
+
+            with open(self.cache_filename,'wb') as handle:
+                 pickle.dump(self.spinnable_cached_forts, handle)
+
+        if not self.spinnable_cached_forts:
+            self.spinnable_cached_forts = copy.deepcopy(self.all_cached_forts)
+        return self.spinnable_cached_forts
+
+    def spin_all_cached_forts(self):
+        destinations = self.sort_cached_forts()
+
+        if not destinations:
+            self.log.info('No more spinnable forts within proximity. Turning on caching mode')
+            self.walk_back_to_origin()
+            self.use_cache = False
+            self.cache_is_sorted = False
+            return False
+
+        for fort_data in destinations:
+            fort = fort_data[0]
+            self.log.info(
+                "Walking to fort at  http://maps.google.com/maps?q=%s,%s",
+                fort['latitude'], fort['longitude'])
+            self.walk_to((fort['latitude'], fort['longitude']), directly=False)
+            self.fort_search_pgoapi(fort, self.get_position(), fort_data[1])
+
+        return True
+
     def login(self, provider, username, password, cached=False):
         if not isinstance(username, basestring) or not isinstance(password, basestring):
             raise AuthException("Username/password not correctly specified")
@@ -1153,23 +1273,28 @@ class PGoApi:
     def main_loop(self):
         catch_attempt = 0
         self.heartbeat()
+        self.setup_cache()
         while True:
             self.heartbeat()
             # self.gsleep(1)
-
-            if self.experimental and self.spin_all_forts:
-                self.spin_all_forts_visible()
+            if self.use_cache:
+                self.spin_all_cached_forts()
             else:
-                self.spin_near_fort()
-            # if catching fails 10 times, maybe you are sofbanned.
-            while self.catch_near_pokemon() and catch_attempt <= self.max_catch_attempts:
-                # self.gsleep(4)
-                catch_attempt += 1
-                pass
-            if catch_attempt > self.max_catch_attempts:
-                self.log.warn("Your account may be softbaned Or no Pokeballs. Failed to catch pokemon %s times",
-                              catch_attempt)
-            catch_attempt = 0
+                if self.experimental and self.spin_all_forts:
+                    self.spin_all_forts_visible()
+                else:
+                    self.spin_near_fort()
+                self.cache_forts(forts = self.new_forts)
+
+                # if catching fails 10 times, maybe you are sofbanned.
+                while self.catch_near_pokemon() and catch_attempt <= self.max_catch_attempts:
+                    # self.gsleep(4)
+                    catch_attempt += 1
+                    pass
+                if catch_attempt > self.max_catch_attempts:
+                    self.log.warn("Your account may be softbaned Or no Pokeballs. Failed to catch pokemon %s times",
+                                  catch_attempt)
+                catch_attempt = 0
 
     @staticmethod
     def flatmap(f, items):


### PR DESCRIPTION
First attempt with a PR with forking and stuff.

Added caching forts, creates a cache file if none, will run cache creation mode unless config.json settings are changed to use the cache. Sorts cache and uses a very simplistic algorithm to find pathing to all points. Will always traverse all points. Can not catch lured pokemon, the point was to reduce get_map_object calls, if someone finds a way to implement it, let me know. Should have experimental tag but I'm way too tired to put that in. I've never coded in Python so this was pretty challenging, excuse anything that looks horrendous (especially def sorted_cached_forts()). I hope the files automatically are attached.