### PR TITLE
Caching forts, saving + loading cache, spin cached forts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib64/
 parts/
 sdist/
 var/
+cache/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Below the accounts you can change options in the `default` section. If you need 
    * `SKIP_VISITED_FORT_DURATION` [Experimental] Avoid a fort for a given number of seconds
      * Setting this to 500 means avoid a fort for 500 seconds before returning, (Should be higher than 300 to have any effect). This will let the bot explore a bigger area.
    * `SPIN_ALL_FORTS` [Experimental] will try to route using google maps(must have key) to all visible forts, if `SKIP_VISITED_FORT_DURATION` is set high enough, you may roam around forever.
+   * `ENABLE_CACHING` is the master switch, no caching methods will run if this is set to false
+   * `USE_CACHED_FORTS` should be set to false on your first run, it will run as normal and cache forts you'd normally visit. Set this to true after you've cached enough forts or "Cached Forts: x" output is stable, around 10 for a 1500 proximity, 100 step configuration, wait longer if needed.
+   * `CACHED_FORTS_SORTED` set to true if the cache is sorted/pathing is calculated. Leave it false if you're unsure.
 * `CAPTURE`
    * `CATCH_POKEMON` Allows you to disabling catching pokemon if you just want to mine for the forts for pokeballs
    * `MIN_FAILED_ATTEMPTS_BEFORE_USING_BERRY` minimum number of failed capture attempts before trying to use a Razz Berry (default: 3)

--- a/config.json.example
+++ b/config.json.example
@@ -16,7 +16,10 @@
         "STAY_WITHIN_PROXIMITY": 9999,
         "AUTO_USE_LUCKY_EGG": false,
         "EXTRA_WAIT" : 0.3,
-        "SLEEP_MULT" : 1.5
+        "SLEEP_MULT" : 1.5,
+        "ENABLE_CACHING" :false,
+        "USE_CACHED_FORTS" : false,
+        "CACHED_FORTS_SORTED" : false
       },
       "CAPTURE": {
         "CATCH_POKEMON": true,

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -29,8 +29,13 @@ Modifications by: Brad Smith <https://github.com/infinitewarp>
 
 from __future__ import absolute_import
 
+import copy
+import hashlib
 import json
 import logging
+import os
+import pickle
+import sys
 from collections import defaultdict
 from itertools import chain
 from time import time
@@ -193,6 +198,14 @@ class PGoApi:
             self.FARM_ITEMS_ENABLED = False
             self.log.warn(
                 "FARM_ITEMS has been disabled due to farming threshold being below the continue. Set 'CATCH_POKEMON' to 'false' to enable captureless traveling.")
+
+        self.new_forts = []
+        self.cache_filename = './cache/cache ' + (hashlib.md5(config.get("location", "unavailable").encode())).hexdigest() + str(self.STAY_WITHIN_PROXIMITY)
+        self.all_cached_forts = []
+        self.spinnable_cached_forts = []
+        self.use_cache = self.config.get("BEHAVIOR", {}).get("USE_CACHED_FORTS", False)
+        self.cache_is_sorted = self.config.get("BEHAVIOR", {}).get("CACHED_FORTS_SORTED", False)
+        self.enable_caching = self.config.get("BEHAVIOR", {}).get("ENABLE_CACHING", False)
 
     '''
     Blocking lock
@@ -591,6 +604,7 @@ class PGoApi:
         forts = PGoApi.flatmap(lambda c: c.get('forts', []), map_cells)
         destinations = filtered_forts(self._origPosF, self._posf, forts, self.STAY_WITHIN_PROXIMITY, self.visited_forts)
         if destinations:
+            self.new_forts = destinations
             nearest_fort = destinations[0][0]
             nearest_fort_dis = destinations[0][1]
             self.log.info("Nearest fort distance is {0:.2f} meters".format(nearest_fort_dis))
@@ -663,6 +677,7 @@ class PGoApi:
             self._error_counter += 1
             self.walk_back_to_origin()
             return False
+        self.new_forts = destinations
         if len(destinations) >= 20:
             destinations = destinations[:20]
         furthest_fort = destinations[0][0]
@@ -696,7 +711,7 @@ class PGoApi:
             self.log.info('No more spinnable forts within proximity. Returning back to origin')
             self.walk_back_to_origin()
             return False
-
+        self.new_forts = destinations
         for fort_data in destinations:
             self.walk_to_fort(fort_data)
 
@@ -1122,6 +1137,108 @@ class PGoApi:
             self.update_player_inventory()
             return False
 
+    def cache_forts(self, forts):
+        if not self.all_cached_forts:
+            with open(self.cache_filename, 'wb') as handle:
+                pickle.dump(forts, handle)
+
+            with open(self.cache_filename, 'rb') as handle:
+                self.all_cached_forts = pickle.load(handle)
+
+            self.log.info("Cache was empty... Dumping in new forts and initializing all_cached_forts")
+
+        else:
+            for fort in forts:
+                if not any(fort[0]['id'] == x[0]['id'] for x in self.all_cached_forts):
+                    self.all_cached_forts.insert(0, fort)
+                    self.log.info("Added new fort to cache")
+
+            with open(self.cache_filename, 'wb') as handle:
+                pickle.dump(self.all_cached_forts, handle)
+
+        self.log.info("Cached forts %s: ", len(self.all_cached_forts))
+
+    def setup_cache(self):
+        try:
+            self.log.debug("Opening cache file...")
+            with open(self.cache_filename, 'rb') as handle:
+                self.all_cached_forts = pickle.load(handle)
+
+        except Exception as e:
+            self.log.debug("Could not find or open cache, making new cache... %s", e)
+            if not os.path.exists('./cache'):
+                os.makedirs('./cache')
+            try:
+                os.remove(self.cache_filename)
+            except OSError:
+                pass
+            with open(self.cache_filename, 'wb') as handle:
+                pickle.dump(self.all_cached_forts, handle)
+
+    def sort_cached_forts(self):
+        if not self.cache_is_sorted:
+            self.log.info("Cache is unsorted, sorting now...")
+            tempallcached = copy.deepcopy(self.all_cached_forts) # copy over original
+            tempsorted = [copy.deepcopy(tempallcached[0])] # the final list to copy to cache
+            tempelement = copy.deepcopy(tempallcached[0]) # cur element
+            tempbool = True
+
+            while (len(tempsorted) < len(self.all_cached_forts)): # sort all elements
+                templastelement = copy.deepcopy(tempsorted[-1])
+                tempelement = copy.deepcopy(tempsorted[0])
+                tempmaxfloat = sys.float_info.max # start with max float to find min distance
+
+                if(tempbool):
+                    for fort in tempallcached:
+                        if distance_in_meters((self._origPosF[0], self._origPosF[1]), (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat:
+                            tempelement = copy.deepcopy(fort)
+                            tempmaxfloat = distance_in_meters((self._origPosF[0], self._origPosF[1]), (fort[0]['latitude'], fort[0]['longitude']))
+
+                    tempsorted.pop(0)
+                    tempsorted.append(tempelement)
+                    tempallcached.remove(tempelement)
+                    tempbool = False
+                else:
+                    for fort in tempallcached:
+                        if ((distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
+                                                (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat) and (not any(fort[0]['id'] == x[0]['id'] for x in tempsorted))):
+                            tempelement = copy.deepcopy(fort)
+                            tempmaxfloat = distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
+                                                              (fort[0]['latitude'], fort[0]['longitude']))
+                    tempallcached.remove(tempelement)
+                    tempsorted.append(tempelement)
+
+            self.spinnable_cached_forts = copy.deepcopy(tempsorted)
+            self.cache_is_sorted = True
+
+            with open(self.cache_filename, 'wb') as handle:
+                pickle.dump(self.spinnable_cached_forts, handle)
+
+        if not self.spinnable_cached_forts:
+            self.spinnable_cached_forts = copy.deepcopy(self.all_cached_forts)
+        return self.spinnable_cached_forts
+
+    def spin_all_cached_forts(self):
+        destinations = self.sort_cached_forts()
+
+        if not destinations:
+            self.log.info('No more spinnable forts within proximity. Turning on caching mode')
+            self.walk_back_to_origin()
+            self.use_cache = False
+            self.cache_is_sorted = False
+            return False
+
+        for fort_data in destinations:
+            fort = fort_data[0]
+            self.log.info(
+                "Walking to fort at  http://maps.google.com/maps?q=%s,%s",
+                fort['latitude'], fort['longitude'])
+            self.walk_to((fort['latitude'], fort['longitude']), directly=False)
+            self.fort_search_pgoapi(fort, self.get_position(), distance_in_meters((fort['latitude'], fort['longitude']),
+                                              (self._posf[0], self._posf[1])))
+
+        return True
+
     def login(self, provider, username, password, oauth2_refresh_token=None):
         if not isinstance(username, basestring) or not isinstance(password, basestring):
             raise AuthException("Username/password not correctly specified")
@@ -1169,20 +1286,31 @@ class PGoApi:
     def main_loop(self):
         catch_attempt = 0
         self.heartbeat()
+        if self.enable_caching and self.experimental:
+            if not self.use_cache:
+                self.log.info('==== CACHING MODE: CACHE FORTS ====')
+            else:
+                self.log.info('==== CACHING MODE: ROUTE+SPIN CACHED FORTS ====')
+            self.setup_cache()
         while True:
             self.heartbeat()
             # self.gsleep(1)
 
-            if self.experimental and self.spin_all_forts:
-                self.spin_all_forts_visible()
+            if self.use_cache and self.experimental and self.enable_caching:
+                self.spin_all_cached_forts()
             else:
-                self.spin_near_fort()
-            # if catching fails 10 times, maybe you are sofbanned.
-            # We can't actually use this as a basis for being softbanned. Pokemon Flee if you are softbanned (~stolencatkarma)
-            while self.catch_near_pokemon() and catch_attempt <= self.max_catch_attempts:
-                # self.gsleep(4)
-                catch_attempt += 1
-                pass
+                if self.experimental and self.spin_all_forts:
+                    self.spin_all_forts_visible()
+                else:
+                    self.spin_near_fort()
+                if self.enable_caching and self.experimental and not self.use_cache:
+                    self.cache_forts(forts=self.new_forts)
+                # if catching fails 10 times, maybe you are sofbanned.
+                # We can't actually use this as a basis for being softbanned. Pokemon Flee if you are softbanned (~stolencatkarma)
+                while self.catch_near_pokemon() and catch_attempt <= self.max_catch_attempts:
+                    # self.gsleep(4)
+                    catch_attempt += 1
+                    pass
             if catch_attempt > self.max_catch_attempts:
                 self.log.warn("You have reached the maximum amount of catch attempts. Giving up after %s times",
                               catch_attempt)

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -1235,7 +1235,7 @@ class PGoApi:
                 fort['latitude'], fort['longitude'])
             self.walk_to((fort['latitude'], fort['longitude']), directly=False)
             self.fort_search_pgoapi(fort, self.get_position(), distance_in_meters((fort['latitude'], fort['longitude']),
-                                              (self._posf[0], self._posf[1])))
+                                                                                  (self._posf[0], self._posf[1])))
 
         return True
 

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -1176,53 +1176,57 @@ class PGoApi:
                 pickle.dump(self.all_cached_forts, handle)
 
     def sort_cached_forts(self):
-        if not self.cache_is_sorted:
-            self.log.info("Cache is unsorted, sorting now...")
-            tempallcached = copy.deepcopy(self.all_cached_forts) # copy over original
-            tempsorted = [copy.deepcopy(tempallcached[0])] # the final list to copy to cache
-            tempelement = copy.deepcopy(tempallcached[0]) # cur element
-            tempbool = True
+        if len(self.all_cached_forts) > 0:
+            if not self.cache_is_sorted:
+                self.log.info("Cache is unsorted, sorting now...")
+                tempallcached = copy.deepcopy(self.all_cached_forts) # copy over original
+                tempsorted = [copy.deepcopy(tempallcached[0])] # the final list to copy to cache
+                tempelement = copy.deepcopy(tempallcached[0]) # cur element
+                tempbool = True
 
-            while (len(tempsorted) < len(self.all_cached_forts)): # sort all elements
-                templastelement = copy.deepcopy(tempsorted[-1])
-                tempelement = copy.deepcopy(tempsorted[0])
-                tempmaxfloat = sys.float_info.max # start with max float to find min distance
+                while (len(tempsorted) < len(self.all_cached_forts)): # sort all elements
+                    templastelement = copy.deepcopy(tempsorted[-1])
+                    tempelement = copy.deepcopy(tempsorted[0])
+                    tempmaxfloat = sys.float_info.max # start with max float to find min distance
 
-                if(tempbool):
-                    for fort in tempallcached:
-                        if distance_in_meters((self._origPosF[0], self._origPosF[1]), (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat:
-                            tempelement = copy.deepcopy(fort)
-                            tempmaxfloat = distance_in_meters((self._origPosF[0], self._origPosF[1]), (fort[0]['latitude'], fort[0]['longitude']))
+                    if(tempbool):
+                        for fort in tempallcached:
+                            if distance_in_meters((self._origPosF[0], self._origPosF[1]), (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat:
+                                tempelement = copy.deepcopy(fort)
+                                tempmaxfloat = distance_in_meters((self._origPosF[0], self._origPosF[1]), (fort[0]['latitude'], fort[0]['longitude']))
 
-                    tempsorted.pop(0)
-                    tempsorted.append(tempelement)
-                    tempallcached.remove(tempelement)
-                    tempbool = False
-                else:
-                    for fort in tempallcached:
-                        if ((distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
-                                                (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat) and (not any(fort[0]['id'] == x[0]['id'] for x in tempsorted))):
-                            tempelement = copy.deepcopy(fort)
-                            tempmaxfloat = distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
-                                                              (fort[0]['latitude'], fort[0]['longitude']))
-                    tempallcached.remove(tempelement)
-                    tempsorted.append(tempelement)
+                        tempsorted.pop(0)
+                        tempsorted.append(tempelement)
+                        tempallcached.remove(tempelement)
+                        tempbool = False
+                    else:
+                        for fort in tempallcached:
+                            if ((distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
+                                                    (fort[0]['latitude'], fort[0]['longitude'])) <= tempmaxfloat) and (not any(fort[0]['id'] == x[0]['id'] for x in tempsorted))):
+                                tempelement = copy.deepcopy(fort)
+                                tempmaxfloat = distance_in_meters((templastelement[0]['latitude'], templastelement[0]['longitude']),
+                                                                  (fort[0]['latitude'], fort[0]['longitude']))
+                        tempallcached.remove(tempelement)
+                        tempsorted.append(tempelement)
 
-            self.spinnable_cached_forts = copy.deepcopy(tempsorted)
-            self.cache_is_sorted = True
+                self.spinnable_cached_forts = copy.deepcopy(tempsorted)
+                self.cache_is_sorted = True
 
-            with open(self.cache_filename, 'wb') as handle:
-                pickle.dump(self.spinnable_cached_forts, handle)
+                with open(self.cache_filename, 'wb') as handle:
+                    pickle.dump(self.spinnable_cached_forts, handle)
 
-        if not self.spinnable_cached_forts:
-            self.spinnable_cached_forts = copy.deepcopy(self.all_cached_forts)
-        return self.spinnable_cached_forts
+            if not self.spinnable_cached_forts:
+                self.spinnable_cached_forts = copy.deepcopy(self.all_cached_forts)
+            return self.spinnable_cached_forts
+        else:
+            self.log.info("Cache is empty! Switching mode to cache forts")
+            return False
 
     def spin_all_cached_forts(self):
         destinations = self.sort_cached_forts()
 
         if not destinations:
-            self.log.info('No more spinnable forts within proximity. Turning on caching mode')
+            self.log.info('Turning on caching mode')
             self.walk_back_to_origin()
             self.use_cache = False
             self.cache_is_sorted = False


### PR DESCRIPTION
Last thread: https://github.com/j-e-k/poketrainer/pull/397

Same thing, lot's of bug fixes I discovered when fixing conflicts and building the cache. Should work, should....

Things to note in config:

```
"ENABLE_CACHING" :true,
"USE_CACHED_FORTS" : false,
"CACHED_FORTS_SORTED" : false
```

**ENABLE_CACHING** is the master switch, no caching methods will run if this is set to false
**USE_CACHED_FORTS** should be set to false on your first run, it will run as normal and cache forts you'd normally visit. Set this to true after your "Cached Forts: x" output is stable, usually 15-60minutes depending on your step and proximity.
**CACHED_FORTS_SORTED** was added for large pokestop counts, if set to true, the cache is already sorted and the code won't run a greedy algorithm to sort the pokestops. If false, the cache will be sorted and saved to file. This will probably be removed in the future, I sorted 400 stops in less than a few seconds, so it's not worth the confusion imo.