### PR TITLE
explain evolution logic in log statements

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -130,6 +130,7 @@
         "FARM_OVERRIDE_STEP_SIZE": -1
       },
       "CONSOLE_OUTPUT": {
+        "EXPLAIN_EVOLUTION_BEFORE_CLEANUP": true,
         "LIST_POKEMON_BEFORE_CLEANUP": true,
         "LIST_INVENTORY_BEFORE_CLEANUP": true
       }


### PR DESCRIPTION
This adds a new config option:
```
      "CONSOLE_OUTPUT": {
        "EXPLAIN_EVOLUTION_BEFORE_CLEANUP": true,
```

When set to true, you will get verbose output in the logs to explain the logic around deciding to evolve pokemon. Looks like this:

```
[ INFO] Not evolving Kakuna because you have 2 but need more than 2.
[ INFO] Pidgey can evolve? True! Need candy: 12. Have candy: 787. Favorite? False. In keep list? False. In evolution list? True.
[ INFO] Evolving pokemon: Type: Pidgey CP: 370, IV: 42.22, Lvl: 23.0, LvlWild: 23.0, MaxCP: 427, Score: 370, IV-Norm.: 36
[ INFO] Evolved to Type: Pidgeotto CP: 701, IV: 42.22, Lvl: 23.0, LvlWild: 23.0, MaxCP: 808, Score: 701, IV-Norm.: 37
[ INFO] Not evolving Pidgeotto because you have 2 but need more than 2.
[ INFO] Not evolving Pidgeot because you have 2 but need more than 2.
[ INFO] Rattata can evolve? False! Need candy: 25. Have candy: 23. Favorite? False. In keep list? False. In evolution list? True.
[ INFO] Scyther can evolve? False! Need candy: None. Have candy: 153. Favorite? False. In keep list? False. In evolution list? False.
```
