### PR TITLE
Multi-Locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ web_config.json
 data_dumps/*.json
 .idea
 .listeners
+encrypt.dll

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ using `docker inspect poketrainer`.
 
 The container is now running in the foregorund, and can be stopped by using `Ctrl+C`. The container can be detached using the sequence `Ctrl+p Ctrl+q`. To stop a container running in the background, run `docker stop poketrainer` and restart it using `docker start poketrainer`. This will start the docker container in the background, attach to it using 'docker attach poketrainer`.
 
-You can create an alias for this by adding `alias pokecli='docker start poketrainer && docker attach poketrainer'` to ~/.bashrc.  	
+You can create an alias for this by adding `alias pokecli='docker start poketrainer && docker attach poketrainer'` to ~/.bashrc.
 
 ### What's working:
 What's working:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Below the accounts you can change options in the `default` section. If you need 
    * `STEP_SIZE` corresponds to how many meters you want to move at most between server calls, set this around 4-6 for walking or 100-200 for really, really fast driving
    * `WANDER_STEPS` will set the distance a pokestop can be away before and still allow us to wander off the walk path. This allows you to get pokestops that aren't close to the sidewalk/road. If you don't set it we won't wander off the path.
    * `EXPERIMENTAL` will set the flag to use exeperimental features
+   * `MULTI_LOCATIONS` will enable the multi-locations functionality. Using this, the bot will be assigned a new location from the "MULTI_LOCATIONS_COORDS" list below when it runs out of PokeStops to visit. It works through the list one by one, eventually returning to your original location.
+   * `MULTI_LOCATIONS_COORDS` a list of locations that you would like the bot to move/walk to. Can be "Lat, Lon", an address, or any other location just like the one you set initially.
    * `SKIP_VISITED_FORT_DURATION` [Experimental] Avoid a fort for a given number of seconds
      * Setting this to 500 means avoid a fort for 500 seconds before returning, (Should be higher than 300 to have any effect). This will let the bot explore a bigger area.
    * `SPIN_ALL_FORTS` [Experimental] will try to route using google maps(must have key) to all visible forts, if `SKIP_VISITED_FORT_DURATION` is set high enough, you may roam around forever.

--- a/config.json.example
+++ b/config.json.example
@@ -11,6 +11,11 @@
         "STEP_SIZE": 100,
         "WANDER_STEPS": 0,
         "EXPERIMENTAL": false,
+        "MULTI_LOCATIONS": true,
+        "MULTI_LOCATIONS_COORDS": [
+            "2415 Trinity St, Los Angeles, CA",
+            "345 E 51st St, Los Angeles, CA"
+        ],
         "SKIP_VISITED_FORT_DURATION": 600,
         "SPIN_ALL_FORTS": true,
         "STAY_WITHIN_PROXIMITY": 9999,

--- a/config.json.example
+++ b/config.json.example
@@ -11,6 +11,7 @@
         "STEP_SIZE": 100,
         "WANDER_STEPS": 0,
         "EXPERIMENTAL": false,
+        "MAP_OBJECTS_RATE_LIMIT": 7.0,
         "MULTI_LOCATIONS": true,
         "MULTI_LOCATIONS_COORDS": [
             "2415 Trinity St, Los Angeles, CA",

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -38,8 +38,8 @@ from time import time
 import gevent
 import six
 from cachetools import TTLCache
-from gevent.coros import BoundedSemaphore
 from geopy.geocoders import GoogleV3
+from gevent.coros import BoundedSemaphore
 
 from pgoapi.auth_google import AuthGoogle
 from pgoapi.auth_ptc import AuthPtc

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -111,7 +111,7 @@ class PGoApi:
         self.inventory = Player_Inventory(self.percentages, [])
 
         self._last_got_map_objects = 0
-        self._map_objects_rate_limit = 5.0
+        self._map_objects_rate_limit = config.get("BEHAVIOR", {}).get("MAP_OBJECTS_RATE_LIMIT", 5.0)
         self.map_objects = {}
         self.encountered_pokemons = TTLCache(maxsize=120, ttl=self._map_objects_rate_limit * 2)
 


### PR DESCRIPTION
Walks to each location in the list whenever "walk to origin" is called.
Takes co-ordinates or addresses. Can be used to guide the bot across a
wider area while keeping "Stay within proximity" low. This is useful
when trying to hit up multiple "good" spots in one run, or hatch eggs by
walking very far between locations before commencing usual botting
behaviours (like hitting every pokestop in an area)

Added get_position_address function (ripped off from pokecli.py) to geocode a location into an address for pretty output within the bot interface (a later commit might take advantage of this)