### PR TITLE
consistently use "new-style" classes

### DIFF
--- a/poketrainer/config.py
+++ b/poketrainer/config.py
@@ -8,7 +8,7 @@ from library.api.pgoapi.protos.POGOProtos.Inventory import \
     Item_pb2 as Item_Enums
 
 
-class Config:
+class Config(object):
 
     def __init__(self, config, cli_args):
         self.log = logging.getLogger(__name__)

--- a/poketrainer/evolve.py
+++ b/poketrainer/evolve.py
@@ -5,7 +5,7 @@ import logging
 from .pokemon import Pokemon
 
 
-class Evolve:
+class Evolve(object):
     def __init__(self, parent):
         self.parent = parent
         self.log = logging.getLogger(__name__)

--- a/poketrainer/fort_walker.py
+++ b/poketrainer/fort_walker.py
@@ -20,7 +20,7 @@ if six.PY3:
     from past.builtins import map
 
 
-class FortWalker:
+class FortWalker(object):
     def __init__(self, parent):
         self.parent = parent
         self.visited_forts = TTLCache(maxsize=120, ttl=self.parent.config.skip_visited_fort_duration)

--- a/poketrainer/incubate.py
+++ b/poketrainer/incubate.py
@@ -5,7 +5,7 @@ import logging
 from .poke_utils import get_pokemon_by_long_id
 
 
-class Incubate:
+class Incubate(object):
     def __init__(self, parent):
         self.parent = parent
         self.log = logging.getLogger(__name__)

--- a/poketrainer/inventory.py
+++ b/poketrainer/inventory.py
@@ -12,7 +12,7 @@ from .poke_utils import get_item_name
 from .pokemon import Pokemon
 
 
-class Inventory:
+class Inventory(object):
     def __init__(self, parent, inventory_items):
         self._parent = parent
         self.inventory_items = inventory_items

--- a/poketrainer/map_objects.py
+++ b/poketrainer/map_objects.py
@@ -6,7 +6,7 @@ from time import time
 from .location import get_neighbors
 
 
-class MapObjects:
+class MapObjects(object):
     def __init__(self, parent):
         self.parent = parent
         self.log = logging.getLogger(__name__)

--- a/poketrainer/player.py
+++ b/poketrainer/player.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import json
 
 
-class Player:
+class Player(object):
     def __init__(self, player_data):
         self.player_data = player_data
         self.username = 0

--- a/poketrainer/player_stats.py
+++ b/poketrainer/player_stats.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from time import time
 
 
-class PlayerStats:
+class PlayerStats(object):
     def __init__(self, player_stats, pokemon_caught=0, start_time=time(), exp_start=None):
         self.player_stats = player_stats
         self.experience = 0

--- a/poketrainer/poke_catcher.py
+++ b/poketrainer/poke_catcher.py
@@ -12,7 +12,7 @@ from .poke_utils import create_capture_probability, get_item_name
 from .pokemon import POKEMON_NAMES, Pokemon
 
 
-class PokeCatcher:
+class PokeCatcher(object):
     def __init__(self, parent):
         self.parent = parent
         self.log = logging.getLogger(__name__)

--- a/poketrainer/poke_lvl_data.py
+++ b/poketrainer/poke_lvl_data.py
@@ -6,7 +6,7 @@ from os import sep as os_sep
 from helper.utilities import take_closest
 
 
-class PokemonLvlData:
+class PokemonLvlData(object):
     def __init__(self):
         self.total_cp_multiplier = 0.0
         self.stardust_to_this_lvl = 0

--- a/poketrainer/poketrainer.py
+++ b/poketrainer/poketrainer.py
@@ -32,7 +32,7 @@ from .sniper import Sniper
 logger = logging.getLogger(__name__)
 
 
-class Poketrainer:
+class Poketrainer(object):
     """ Public functions (without _**) are callable by the webservice! """
 
     def __init__(self, args):

--- a/poketrainer/release.py
+++ b/poketrainer/release.py
@@ -6,7 +6,7 @@ from six import iteritems
 from .release_methods.base import ReleaseMethodFactory
 
 
-class Release:
+class Release(object):
     def __init__(self, parent):
         self.parent = parent
         self.log = logging.getLogger(__name__)

--- a/poketrainer/sniper.py
+++ b/poketrainer/sniper.py
@@ -9,7 +9,7 @@ from .pokedex import pokedex
 from .pokemon import POKEMON_NAMES
 
 
-class Sniper:
+class Sniper(object):
     def __init__(self, parent):
         self.parent = parent
         self.log = logging.getLogger(__name__)


### PR DESCRIPTION
I'm kind of surprised we have such an odd mix of old-style and new-style Python classes.

(I hesitate to say "new-style" since they've been the norm for ages. 😛)

There only immediate benefit to the switch is than consistency across the code (some classes already extend `object` or an ancestor of it) and Python versions (Python 3 *always* uses new-style classes). Using new-style classes could enable us to do some funky metaclass programming, even though that's probably not likely here.

Any objections?