### PR TITLE
redirect to status page after transferring a pokemon; show transferred/failed flash at top of page

### DIFF
--- a/web.py
+++ b/web.py
@@ -219,7 +219,7 @@ def transfer(username, p_id):
         flash("Released")
     else:
         flash("Failed!")
-    return redirect(url_for('inventory', username=username))
+    return redirect(url_for('status', username=username))
 
 
 @app.route("/<username>/snipe/<latlng>")

--- a/web/templates/status.html
+++ b/web/templates/status.html
@@ -37,6 +37,13 @@
     </div>
     <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
       <div style="display: none;" class="alert" role="alert" id="alert-box"></div>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    {% for message in messages %}
+      <div class="alert alert-info" role="alert" id="alert-box">{{ message }}</div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
       <div id="overlay" class="map">
         <iframe id="map" src="https://maps.google.com/maps?q={{latlng}}&z=15&output=embed" width="100%" height="800" frameborder="0" style="border:0"></iframe>
       </div>


### PR DESCRIPTION
addresses https://github.com/j-e-k/poketrainer/issues/489