### PR TITLE
Add CP/IV preference for classic release method

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -64,7 +64,8 @@
         "RELEASE_METHOD": "CLASSIC",
         "RELEASE_METHOD_CLASSIC": {
           "KEEP_CP_OVER": 2000,
-          "KEEP_IV_OVER": 85
+          "KEEP_IV_OVER": 85,
+          "PREFER": "CP"
         },
         "SCORE_METHOD": "IV",
         "SCORE_METHOD_FANCY": {

--- a/poketrainer/release_methods/classic.py
+++ b/poketrainer/release_methods/classic.py
@@ -14,16 +14,18 @@ class ReleaseMethod(base.ReleaseMethod):
         self.throw_pokemon_ids = map(lambda x: getattr(Enums_pb2, x), config.get("THROW_POKEMON_NAMES", []))
         self.keep_cp_over = self.config.get('RELEASE_METHOD_CLASSIC', {}).get('KEEP_CP_OVER', 0)
         self.keep_iv_over = self.config.get('RELEASE_METHOD_CLASSIC', {}).get('KEEP_IV_OVER', 0)
+        self.prefer = self.config.get('RELEASE_METHOD_CLASSIC', {}).get('PREFER', 'CP')
         self.max_similar_pokemon = self.config.get('MAX_SIMILAR_POKEMON', 999)
         self.min_similar_pokemon = self.config.get('MIN_SIMILAR_POKEMON', 1)
+
+        self.sort_key = lambda x: (x.cp, x.iv) if self.prefer == 'CP' else lambda x: (x.iv, x.cp)
 
     def get_pokemon_to_release(self, pokemon_id, pokemons):
         pokemon_to_release = []
         pokemon_to_keep = []
 
         if len(pokemons) > self.min_similar_pokemon:
-            # sorting for CLASSIC method as default
-            sorted_pokemons = sorted(pokemons, key=lambda x: (x.cp, x.iv), reverse=True)
+            sorted_pokemons = sorted(pokemons, key=self.sort_key, reverse=True)
 
             kept_pokemon_of_type = self.min_similar_pokemon
             pokemon_to_keep = sorted_pokemons[0:self.min_similar_pokemon]


### PR DESCRIPTION
Adds CP or IV preference for the classic release method. Checks for a `"PREFER"` key in the config that takes a value of either `"CP"` or `"IV"`. For example:

```
"POKEMON_CLEANUP": {
        "MIN_SIMILAR_POKEMON": 1,
        "RELEASE_METHOD": "CLASSIC",
        "RELEASE_METHOD_CLASSIC": {
          "KEEP_CP_OVER": 2000,
          "KEEP_IV_OVER": 85,
          "PREFER": "CP"
        },
```

Will keep _at least_ the 1 highest CP Pokemon of each type.

```
"POKEMON_CLEANUP": {
        "MIN_SIMILAR_POKEMON": 1,
        "RELEASE_METHOD": "CLASSIC",
        "RELEASE_METHOD_CLASSIC": {
          "KEEP_CP_OVER": 2000,
          "KEEP_IV_OVER": 85,
          "PREFER": "IV"
        },
```

Will keep _at least_ the 1 highest IV Pokemon of each type.